### PR TITLE
feat/74: before clean - add authentication, migrations

### DIFF
--- a/internal/api/handlers/auth_handler.go
+++ b/internal/api/handlers/auth_handler.go
@@ -1,0 +1,90 @@
+package handlers
+
+import (
+	"context"
+	"errors"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/yandex-development-1-team/go/internal/models"
+)
+
+type AuthorisationService interface {
+	Login(context.Context, string, string) (*models.AuthResult, error)
+}
+
+type AuthHandler struct {
+	service AuthorisationService
+}
+
+func NewAuthHandler(service AuthorisationService) *AuthHandler {
+	return &AuthHandler{
+		service: service,
+	}
+}
+
+func (ah *AuthHandler) HandleLogin(c *gin.Context) {
+	var loginData LoginData
+	if err := c.ShouldBindJSON(&loginData); err != nil {
+		// logger.Error("bad_request", zap.Error(err), zap.String("operation", "HandleLogin"))
+		errorWriter(c, models.ErrInvalidInput)
+		return
+		// if err := json.NewDecoder(r.Body).Decode(&loginData); err != nil {
+		// 	// logger.Info("") // дописать
+		// 	BadRequestError(w, err.Error())
+		// 	return
+	}
+
+	authResult, err := ah.service.Login(c.Request.Context(), loginData.Login, loginData.Password)
+	if err != nil {
+		// обработка и логирование ошибок должны быть в middleware
+		errorWriter(c, err)
+		return
+	}
+
+	userResponse := toUserResponse(authResult.User)
+
+	response := LoginSuccessful{
+		Token:        authResult.Token,
+		RefreshToken: authResult.RefreshToken,
+		User:         userResponse,
+	}
+
+	c.JSON(http.StatusOK, response)
+}
+
+func toUserResponse(user *models.UserAPI) UserResponse {
+	userResponse := UserResponse{
+		ID:           user.ID,
+		TelegramNick: user.TelegramNick,
+		Name:         user.Name,
+		Email:        user.Email,
+		Role:         user.Role,
+		Status:       user.Status,
+		Permissions:  user.Permissions,
+		CreatedAt:    user.CreatedAt,
+		UpdatedAt:    user.UpdatedAt,
+	}
+
+	return userResponse
+}
+
+func errorWriter(c *gin.Context, err error) {
+	switch {
+	case errors.Is(err, models.ErrInvalidCredentials),
+		errors.Is(err, models.ErrUserNotFound):
+		// logger.Info("wrong_credentials", zap.Error(err), zap.String("operation", "HandleLogin"))
+		c.JSON(http.StatusUnauthorized, UnauthorizedError("неверный логин или пароль"))
+
+	case errors.Is(err, models.ErrInvalidInput):
+		c.JSON(http.StatusBadRequest, BadRequestError())
+
+	case errors.Is(err, models.ErrUserBlocked):
+		// logger.Info("user_blocked", zap.Error(err), zap.String("operation", "HandleLogin"))
+		c.JSON(http.StatusForbidden, ForbiddenError())
+
+	default:
+		// logger.Info("internal_error", zap.Error(err), zap.String("operation", "HandleLogin"))
+		c.JSON(http.StatusInternalServerError, InternalServerError())
+	}
+}

--- a/internal/api/handlers/responses.go
+++ b/internal/api/handlers/responses.go
@@ -1,0 +1,30 @@
+package handlers
+
+func UnauthorizedError(detail string) *MessageResponse {
+	return &MessageResponse{
+		Message: "Неавторизован",
+		Status:  StatusError,
+		Details: []MessageDetail{{Message: detail}},
+	}
+}
+
+func BadRequestError() *MessageResponse {
+	return &MessageResponse{
+		Message: "Не валидные входные данные",
+		Status:  StatusError,
+	}
+}
+
+func ForbiddenError() *MessageResponse {
+	return &MessageResponse{
+		Message: "Недостаточно прав",
+		Status:  StatusError,
+	}
+}
+
+func InternalServerError() *MessageResponse {
+	return &MessageResponse{
+		Message: "Внутренняя ошибка сервера",
+		Status:  StatusError,
+	}
+}

--- a/internal/api/handlers/schemas.go
+++ b/internal/api/handlers/schemas.go
@@ -1,0 +1,35 @@
+package handlers
+
+type MessageStatus string
+
+const (
+	StatusError   MessageStatus = "error"
+	StatusSuccess MessageStatus = "success"
+	StatusInfo    MessageStatus = "info"
+)
+
+type MessageResponse struct {
+	Message string          `json:"message"`
+	Status  MessageStatus   `json:"status"`
+	Details []MessageDetail `json:"details,omitempty"`
+}
+
+type MessageDetail struct {
+	Field   string `json:"field,omitempty"`
+	Message string `json:"message"`
+}
+
+// type ErrorDetail struct {
+// 	Field   string `json:"field"`
+// 	Message string `json:"message"`
+// }
+
+// type ErrorBody struct {
+// 	Code    string        `json:"code"`
+// 	Message string        `json:"message"`
+// 	Details []ErrorDetail `json:"details,omitempty"`
+// }
+
+// type ErrorResponse struct {
+// 	Error ErrorBody `json:"error"`
+// }

--- a/internal/api/handlers/user.go
+++ b/internal/api/handlers/user.go
@@ -1,0 +1,35 @@
+package handlers
+
+import "time"
+
+type LoginData struct {
+	Login    string `json:"login"`
+	Password string `json:"password"`
+}
+
+type LoginSuccessful struct {
+	Token        string       `json:"token"`
+	RefreshToken string       `json:"refresh_token"`
+	User         UserResponse `json:"user"`
+}
+
+type UserResponse struct {
+	ID           int64     `json:"id"`
+	TelegramNick string    `json:"telegram_nick"`
+	Name         string    `json:"name"`
+	Email        string    `json:"email"`
+	Role         string    `json:"role"`
+	Status       string    `json:"status"`
+	Permissions  []string  `json:"permissions"`
+	CreatedAt    time.Time `json:"created_at"`
+	UpdatedAt    time.Time `json:"updated_at"`
+}
+
+var rolePermissions = map[string][]string{
+	"admin":   {"users:read", "users:write", "users:delete", "events:read", "events:write"},
+	"manager": {"users:read", "events:read", "events:write"},
+}
+
+func PermissionsByRole(role string) []string {
+	return rolePermissions[role]
+}

--- a/internal/api/handlers/user_clean_test.go
+++ b/internal/api/handlers/user_clean_test.go
@@ -1,0 +1,251 @@
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/docker/go-connections/nat"
+	"github.com/gin-gonic/gin"
+	"github.com/jmoiron/sqlx"
+	"github.com/pressly/goose/v3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	tc "github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/wait"
+	repository "github.com/yandex-development-1-team/go/internal/repository/postgres"
+	service "github.com/yandex-development-1-team/go/internal/service/api"
+	"golang.org/x/crypto/bcrypt"
+)
+
+type seedUserParams struct {
+	TelegramID int64
+	Email      string
+	Role       string
+	Status     string
+	PassHash   string
+}
+
+func setupServer(t *testing.T, db *sqlx.DB) *httptest.Server {
+	t.Helper()
+
+	userRepo := repository.NewUserRepo(db)
+	refreshRepo := repository.NewRefreshTokenRepo(db)
+	svc := service.GetNewAuthService(userRepo, refreshRepo)
+	handler := NewAuthHandler(svc)
+
+	router := gin.New()
+	router.POST("/auth/login", handler.HandleLogin)
+
+	server := httptest.NewServer(router)
+	t.Cleanup(server.Close)
+	return server
+}
+
+func seedUser(t *testing.T, db *sqlx.DB, p seedUserParams) {
+	t.Helper()
+	_, err := db.Exec(`
+			INSERT INTO users (telegram_id, email, role, status, password_hash)
+			VALUES ($1, $2, $3, $4, $5)`,
+		p.TelegramID, p.Email, p.Role, p.Status, p.PassHash,
+	)
+	require.NoError(t, err)
+}
+
+func TestHandleLogin(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	container, err := startContainer()
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, container.Terminate(ctx))
+	}()
+
+	db, err := createDB(container)
+	require.NoError(t, err)
+	defer db.Close()
+
+	server := setupServer(t, db)
+
+	validHash, err := bcrypt.GenerateFromPassword([]byte("password123"), bcrypt.MinCost)
+	require.NoError(t, err)
+
+	// role — только 'admin' или 'manager', нет 'user'
+	seedUser(t, db, seedUserParams{
+		TelegramID: 1,
+		Email:      "user@example.com",
+		Status:     "active",
+		Role:       "manager",
+		PassHash:   string(validHash),
+	})
+
+	seedUser(t, db, seedUserParams{
+		TelegramID: 2,
+		Email:      "blocked@example.com",
+		Status:     "blocked",
+		Role:       "manager",
+		PassHash:   string(validHash),
+	})
+
+	tests := []struct {
+		name       string
+		body       any
+		wantStatus int
+		checkBody  func(*testing.T, map[string]any)
+	}{
+		{
+			name:       "успешный логин",
+			body:       map[string]string{"login": "user@example.com", "password": "password123"},
+			wantStatus: http.StatusOK,
+			checkBody: func(t *testing.T, body map[string]any) {
+				assert.NotEmpty(t, body["token"])
+				assert.NotEmpty(t, body["refresh_token"])
+
+				user, ok := body["user"].(map[string]any)
+				require.True(t, ok, "user field missing or wrong type")
+				assert.Equal(t, "user@example.com", user["email"])
+				assert.Equal(t, "manager", user["role"])
+				assert.Equal(t, "active", user["status"])
+			},
+		},
+		{
+			name:       "неверный пароль",
+			body:       map[string]string{"login": "user@example.com", "password": "wrongpass"},
+			wantStatus: http.StatusUnauthorized,
+			checkBody: func(t *testing.T, body map[string]any) {
+				assert.Equal(t, "error", body["status"])
+				assert.NotEmpty(t, body["message"])
+			},
+		},
+		{
+			name:       "пользователь не найден",
+			body:       map[string]string{"login": "notfound@example.com", "password": "password123"},
+			wantStatus: http.StatusUnauthorized,
+			checkBody: func(t *testing.T, body map[string]any) {
+				assert.Equal(t, "error", body["status"])
+				assert.NotEmpty(t, body["message"])
+			},
+		},
+		{
+			name:       "заблокированный пользователь",
+			body:       map[string]string{"login": "blocked@example.com", "password": "password123"},
+			wantStatus: http.StatusForbidden,
+			checkBody: func(t *testing.T, body map[string]any) {
+				assert.Equal(t, "error", body["status"])
+				assert.NotEmpty(t, body["message"])
+			},
+		},
+		{
+			name:       "короткий пароль",
+			body:       map[string]string{"login": "user@example.com", "password": "123"},
+			wantStatus: http.StatusBadRequest,
+			checkBody: func(t *testing.T, body map[string]any) {
+				assert.Equal(t, "error", body["status"])
+			},
+		},
+		{
+			name:       "пустой email",
+			body:       map[string]string{"login": "", "password": "password123"},
+			wantStatus: http.StatusBadRequest,
+			checkBody: func(t *testing.T, body map[string]any) {
+				assert.Equal(t, "error", body["status"])
+			},
+		},
+		{
+			name:       "невалидный json",
+			body:       "not json",
+			wantStatus: http.StatusBadRequest,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body, err := json.Marshal(tt.body)
+			require.NoError(t, err)
+
+			resp, err := http.Post(
+				server.URL+"/auth/login",
+				"application/json",
+				bytes.NewReader(body),
+			)
+			require.NoError(t, err)
+			defer resp.Body.Close()
+
+			assert.Equal(t, tt.wantStatus, resp.StatusCode)
+
+			if tt.checkBody != nil {
+				var result map[string]any
+				require.NoError(t, json.NewDecoder(resp.Body).Decode(&result))
+				tt.checkBody(t, result)
+			}
+		})
+	}
+}
+
+func startContainer() (tc.Container, error) {
+	// настройка testcontainers postgres
+	req := tc.ContainerRequest{
+		Image:        "postgres:latest",
+		ExposedPorts: []string{"5432/tcp"},
+		Env: map[string]string{
+			"POSTGRES_PASSWORD": "password",
+			"POSTGRES_DB":       "testdb",
+		},
+		WaitingFor: wait.ForSQL(
+			nat.Port("5432/tcp"),
+			"postgres",
+			func(host string, port nat.Port) string {
+				return fmt.Sprintf(
+					"host=%s port=%s user=postgres password=password dbname=postgres sslmode=disable connect_timeout=5",
+					host, port.Port())
+			}).
+			WithStartupTimeout(120 * time.Second),
+	}
+
+	// генерация контейнера
+	dbContainer, err := tc.GenericContainer(
+		context.Background(),
+		tc.GenericContainerRequest{
+			ContainerRequest: req,
+			Started:          true,
+		})
+	if err != nil {
+		fmt.Printf("Container logs: %v\n", err)
+		return nil, err
+	}
+
+	return dbContainer, err
+}
+
+func createDB(container tc.Container) (*sqlx.DB, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	host, _ := container.Host(context.Background())
+	port, _ := container.MappedPort(context.Background(), "5432")
+
+	dbURI := fmt.Sprintf(
+		"host=%s port=%s user=postgres password=password dbname=testdb sslmode=disable",
+		host, port.Port())
+
+	db, err := sqlx.Connect("postgres", dbURI)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := goose.SetDialect("postgres"); err != nil {
+		return nil, err
+	}
+
+	if err := goose.UpContext(ctx, db.DB, "../../../migrations"); err != nil {
+		return nil, err
+	}
+
+	return db, nil
+}

--- a/internal/repository/postgres/refresh_token.go
+++ b/internal/repository/postgres/refresh_token.go
@@ -1,0 +1,42 @@
+package repository
+
+import (
+	"context"
+	"time"
+
+	"github.com/jmoiron/sqlx"
+)
+
+type RefreshTokenRepo struct {
+	db *sqlx.DB
+}
+
+func NewRefreshTokenRepo(db *sqlx.DB) *RefreshTokenRepo {
+	return &RefreshTokenRepo{
+		db: db,
+	}
+}
+
+func (rf *RefreshTokenRepo) CreateRefreshToken(ctx context.Context, userId int64, token string, expiresAt time.Time) error {
+	query := `
+	INSERT INTO refresh_tokens (user_id, token, expires_at)
+	VALUES ($1, $2, $3)
+	`
+	tx, err := rf.db.Begin()
+	defer tx.Rollback()
+	if err != nil {
+		return err
+	}
+
+	_, err = tx.ExecContext(ctx, query, userId, token, expiresAt)
+	if err != nil {
+		return err
+	}
+
+	err = tx.Commit()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/internal/repository/postgres/user.go
+++ b/internal/repository/postgres/user.go
@@ -1,0 +1,21 @@
+package repository
+
+import (
+	"time"
+
+	"github.com/lib/pq"
+)
+
+type userRow struct {
+	ID           int64          `db:"id"`
+	TelegramNick *string        `db:"username"`
+	FirstName    *string        `db:"first_name"`
+	LastName     *string        `db:"last_name"`
+	Email        string         `db:"email"`
+	UserPass     string         `db:"password_hash"` // проверить
+	Role         string         `db:"role"`
+	Status       string         `db:"status"`
+	Permissions  pq.StringArray `db:"permissions"`
+	CreatedAt    time.Time      `db:"created_at"`
+	UpdatedAt    time.Time      `db:"updated_at"`
+}

--- a/internal/repository/postgres/user_repo.go
+++ b/internal/repository/postgres/user_repo.go
@@ -1,0 +1,68 @@
+package repository
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"strings"
+
+	"github.com/jmoiron/sqlx"
+	"github.com/yandex-development-1-team/go/internal/models"
+)
+
+type UserRepo struct {
+	db *sqlx.DB
+}
+
+func NewUserRepo(db *sqlx.DB) *UserRepo {
+	return &UserRepo{
+		db: db,
+	}
+}
+
+func (u *UserRepo) GetUserByEmail(ctx context.Context, email string) (*models.UserWithAuth, error) {
+	//operation := "get_user"
+	//return withMetricsValue(operation, func() (*models.UserWithAuth, error) {
+
+	query := `
+    SELECT id, username, first_name, last_name, email, 
+           role, status, permissions, password_hash, created_at, updated_at
+    FROM users
+    WHERE email = $1`
+
+	var user userRow
+	err := u.db.GetContext(ctx, &user, query, email)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, models.ErrUserNotFound
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	return &models.UserWithAuth{
+		User:     toUser(&user),
+		PassHash: user.UserPass,
+	}, nil
+	//})
+}
+
+func toUser(user *userRow) *models.UserAPI {
+	return &models.UserAPI{
+		ID:           user.ID,
+		TelegramNick: derefString(user.TelegramNick),
+		Name:         strings.TrimSpace(derefString(user.FirstName) + " " + derefString(user.LastName)),
+		Email:        user.Email,
+		Role:         user.Role,
+		Status:       user.Status,
+		Permissions:  user.Permissions,
+		CreatedAt:    user.CreatedAt,
+		UpdatedAt:    user.UpdatedAt,
+	}
+}
+
+func derefString(s *string) string {
+	if s == nil {
+		return ""
+	}
+	return *s
+}

--- a/internal/service/api/auth_service.go
+++ b/internal/service/api/auth_service.go
@@ -1,0 +1,132 @@
+package service
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/yandex-development-1-team/go/internal/models"
+	"golang.org/x/crypto/bcrypt"
+)
+
+type Claims struct {
+	UserID               int64  `json:"uid"`
+	Role                 string `json:"role"`
+	jwt.RegisteredClaims        // exp, iat, iss, jti — стандартные поля
+}
+
+type UserApiRepository interface {
+	GetUserByEmail(ctx context.Context, email string) (*models.UserWithAuth, error)
+	// GetAuthInfo(ctx context.Context, email string) (string, error)
+}
+
+type RefreshTokenRepository interface {
+	CreateRefreshToken(context.Context, int64, string, time.Time) error
+}
+
+type AuthService struct {
+	userRepo    UserApiRepository
+	refreshRepo RefreshTokenRepository
+}
+
+func GetNewAuthService(userRepo UserApiRepository, refreshRepo RefreshTokenRepository) *AuthService {
+	return &AuthService{
+		userRepo:    userRepo,
+		refreshRepo: refreshRepo,
+	}
+}
+
+func (as *AuthService) Login(ctx context.Context, email, password string) (*models.AuthResult, error) {
+	// проверка на ошибочный ввод и атаки
+	if len(email) == 0 || len(password) < 8 {
+		return nil, models.ErrInvalidInput
+	}
+
+	authInfo, err := as.userRepo.GetUserByEmail(ctx, email)
+	if err != nil {
+		return nil, err
+	}
+
+	user := authInfo.User
+	if err = CheckPassword(password, authInfo.PassHash); err != nil {
+		if errors.Is(err, bcrypt.ErrMismatchedHashAndPassword) {
+			return nil, models.ErrInvalidCredentials
+		}
+		return nil, fmt.Errorf("check password: %w", err)
+	}
+
+	if user.Status == "blocked" {
+		return nil, models.ErrUserBlocked
+	}
+
+	token, err := generateToken(user.ID, user.Role)
+	if err != nil {
+		return nil, err
+	}
+
+	refreshToken, err := generateRefreshToken()
+	if err != nil {
+		return nil, err
+	}
+
+	expiresAt := time.Now().Add(30 * 24 * time.Hour)
+	err = as.refreshRepo.CreateRefreshToken(ctx, user.ID, refreshToken, expiresAt)
+	if err != nil {
+		return nil, err
+	}
+
+	return &models.AuthResult{
+		User:         user,
+		Token:        token,
+		RefreshToken: refreshToken,
+	}, nil
+}
+
+func CheckPassword(password, hash string) error {
+	return bcrypt.CompareHashAndPassword([]byte(hash), []byte(password))
+}
+
+func HashPassword(password string) (string, error) {
+	// DefultCost для баланса защиты и скрости работы
+	hash, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
+	if err != nil {
+		return "", err
+	}
+	return string(hash), nil
+}
+
+func generateToken(userId int64, role string) (string, error) {
+	claims := Claims{
+		UserID: userId,
+		Role:   role,
+		RegisteredClaims: jwt.RegisteredClaims{
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(15 * time.Minute)),
+			IssuedAt:  jwt.NewNumericDate(time.Now()),
+		},
+	}
+
+	jwtToken := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+
+	signedToken, err := jwtToken.SignedString([]byte("secret_key")) // заменить Secret на строку из конфига
+	if err != nil {
+		return "", err
+	}
+
+	return signedToken, nil
+}
+
+func generateRefreshToken() (string, error) {
+	refreshTokenRaw := make([]byte, 32)
+
+	_, err := rand.Read(refreshTokenRaw)
+	if err != nil {
+		return "", err
+	}
+
+	refreshToken := base64.RawURLEncoding.EncodeToString(refreshTokenRaw)
+	return refreshToken, nil
+}

--- a/migrations/20260209150247_create_users_table.sql
+++ b/migrations/20260209150247_create_users_table.sql
@@ -25,9 +25,11 @@ CREATE TABLE IF NOT EXISTS users (
     grade SMALLINT DEFAULT 0,
     is_admin BOOLEAN DEFAULT FALSE,
     password_hash TEXT NOT NULL,
-    role user_role_type NOT NULL,
-    status user_status_type NOT NULL,
-    email VARCHAR(255),
+    role user_role_type  DEFAULT 'manager',
+    status user_status_type  DEFAULT 'invited',
+    invite_token TEXT,
+    permissions TEXT[] DEFAULT '{}',
+    email VARCHAR(255) NOT NULL UNIQUE,
     created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );

--- a/migrations/20260307175154_create_refresh_table.sql
+++ b/migrations/20260307175154_create_refresh_table.sql
@@ -1,0 +1,19 @@
+-- +goose Up
+
+CREATE TABLE IF NOT EXISTS refresh_tokens (
+    id BIGSERIAL PRIMARY KEY,
+    user_id BIGINT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    token TEXT UNIQUE NOT NULL,
+    expires_at TIMESTAMPTZ NOT NULL,
+    revoked_at TIMESTAMPTZ NULL,
+    created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_refresh_tokens_token ON refresh_tokens(token);
+CREATE INDEX IF NOT EXISTS idx_refresh_tokens_user_id ON refresh_tokens(user_id);
+
+-- +goose Down
+DROP INDEX IF EXISTS idx_refresh_tokens_token;
+DROP INDEX IF EXISTS idx_refresh_tokens_user_id;
+
+DROP TABLE IF EXISTS refresh_tokens;


### PR DESCRIPTION
Версия до полного OAS3 от Ильи. Мержить не буду. После получения спеки все поправлю и состыкуем с остальными готовыми тасками

Добавлено:
1. Аутентификация пользователя по email
2. Создание токена и рефреш-токена (для корректного ответа добавлено поле рефреш-токена)
3. Добавлены тесты httptest + testscontainers для бд