### PR TITLE
Feat/81

### DIFF
--- a/internal/api/application_handler.go
+++ b/internal/api/application_handler.go
@@ -24,6 +24,9 @@ func NewApplicationHandler(repo repository.ApplicationRepository) *applicationHa
 func (h *applicationHandler) RegisterRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("POST /api/v1/applications", h.create)
 	mux.HandleFunc("GET /api/v1/applications", h.list)
+	mux.HandleFunc("GET /api/v1/applications/{id}", h.getByID)
+	mux.HandleFunc("PUT /api/v1/applications/{id}", h.update)
+	mux.HandleFunc("DELETE /api/v1/applications/{id}", h.delete)
 }
 
 func (h *applicationHandler) create(w http.ResponseWriter, r *http.Request) {
@@ -121,6 +124,95 @@ func (h *applicationHandler) list(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+func (h *applicationHandler) getByID(w http.ResponseWriter, r *http.Request) {
+	id, ok := parseID(w, r)
+	if !ok {
+		return
+	}
+
+	app, err := h.repo.GetApplicationByID(r.Context(), id)
+	if err != nil {
+		if errors.Is(err, models.ErrApplicationNotFound) {
+			writeNotFoundError(w)
+			return
+		}
+		logger.Error("failed to get application by id", zap.Error(err))
+		writeInternalError(w)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, app)
+}
+
+func (h *applicationHandler) update(w http.ResponseWriter, r *http.Request) {
+	id, ok := parseID(w, r)
+	if !ok {
+		return
+	}
+
+	var req models.ApplicationUpdateRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeValidationError(w, validationDetail{Field: "body", Message: "invalid JSON"})
+		return
+	}
+
+	if req.Status == nil && req.ContactInfo == nil && req.BoxID == nil && req.SpecialProjectID == nil {
+		writeValidationError(w, validationDetail{Field: "body", Message: "at least one field must be provided"})
+		return
+	}
+
+	if req.Status != nil && !req.Status.Valid() {
+		writeValidationError(w, validationDetail{Field: "status", Message: "must be one of: queue, in_progress, done"})
+		return
+	}
+
+	app, err := h.repo.UpdateApplication(r.Context(), id, &req)
+	if err != nil {
+		if errors.Is(err, models.ErrApplicationNotFound) {
+			writeNotFoundError(w)
+			return
+		}
+		if errors.Is(err, models.ErrInvalidInput) {
+			writeValidationError(w, validationDetail{Field: "body", Message: err.Error()})
+			return
+		}
+		logger.Error("failed to update application", zap.Error(err))
+		writeInternalError(w)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, app)
+}
+
+func (h *applicationHandler) delete(w http.ResponseWriter, r *http.Request) {
+	id, ok := parseID(w, r)
+	if !ok {
+		return
+	}
+
+	if err := h.repo.DeleteApplication(r.Context(), id); err != nil {
+		if errors.Is(err, models.ErrApplicationNotFound) {
+			writeNotFoundError(w)
+			return
+		}
+		logger.Error("failed to delete application", zap.Error(err))
+		writeInternalError(w)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]string{"message": "application deleted"})
+}
+
+func parseID(w http.ResponseWriter, r *http.Request) (int64, bool) {
+	raw := r.PathValue("id")
+	id, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil || id <= 0 {
+		writeValidationError(w, validationDetail{Field: "id", Message: "must be a positive integer"})
+		return 0, false
+	}
+	return id, true
+}
+
 type validationDetail struct {
 	Field   string `json:"field"`
 	Message string `json:"message"`
@@ -149,6 +241,12 @@ func writeValidationErrors(w http.ResponseWriter, details []validationDetail) {
 	var resp errorResponse
 	resp.Error.Details = details
 	writeJSON(w, http.StatusBadRequest, resp)
+}
+
+func writeNotFoundError(w http.ResponseWriter) {
+	var resp errorResponse
+	resp.Error.Message = "not found"
+	writeJSON(w, http.StatusNotFound, resp)
 }
 
 func writeInternalError(w http.ResponseWriter) {

--- a/internal/api/application_handler.go
+++ b/internal/api/application_handler.go
@@ -156,7 +156,7 @@ func (h *applicationHandler) update(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if req.Status == nil && req.ContactInfo == nil && req.BoxID == nil && req.SpecialProjectID == nil {
+	if !req.HasUpdates() {
 		writeValidationError(w, validationDetail{Field: "body", Message: "at least one field must be provided"})
 		return
 	}

--- a/internal/api/application_handler_test.go
+++ b/internal/api/application_handler_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/yandex-development-1-team/go/internal/models"
 )
 
-// mockApplicationRepo implements repository.ApplicationRepository for unit tests.
 type mockApplicationRepo struct {
 	createFn      func(ctx context.Context, req *models.ApplicationCreateRequest) (*models.Application, error)
 	listFn        func(ctx context.Context, filter models.ApplicationFilter) ([]models.Application, int, error)
@@ -59,8 +58,6 @@ func sampleApp() *models.Application {
 	}
 }
 
-// ── create ────────────────────────────────────────────────────────────────────
-
 func TestCreate_HappyPath(t *testing.T) {
 	repo := &mockApplicationRepo{
 		createFn: func(_ context.Context, _ *models.ApplicationCreateRequest) (*models.Application, error) {
@@ -94,8 +91,6 @@ func TestCreate_ValidationError(t *testing.T) {
 
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 }
-
-// ── list ─────────────────────────────────────────────────────────────────────
 
 func TestList_HappyPath(t *testing.T) {
 	repo := &mockApplicationRepo{
@@ -132,8 +127,6 @@ func TestList_EmptyReturnsEmptySlice(t *testing.T) {
 	assert.NotNil(t, resp.Items)
 	assert.Len(t, resp.Items, 0)
 }
-
-// ── getByID ───────────────────────────────────────────────────────────────────
 
 func TestGetByID_HappyPath(t *testing.T) {
 	repo := &mockApplicationRepo{
@@ -187,8 +180,6 @@ func TestGetByID_ZeroID(t *testing.T) {
 
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 }
-
-// ── update ────────────────────────────────────────────────────────────────────
 
 func TestUpdate_HappyPath(t *testing.T) {
 	status := models.ApplicationStatusInProgress
@@ -261,6 +252,18 @@ func TestUpdate_InvalidID(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 }
 
+func TestUpdate_NegativeID(t *testing.T) {
+	repo := &mockApplicationRepo{}
+	status := models.ApplicationStatusDone
+	body, _ := json.Marshal(models.ApplicationUpdateRequest{Status: &status})
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPut, "/api/v1/applications/-5", bytes.NewReader(body))
+	newHandlerMux(repo).ServeHTTP(w, r)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
 func TestUpdate_AllowedFields(t *testing.T) {
 	contact := "new@example.com"
 	boxID := int64(7)
@@ -284,8 +287,6 @@ func TestUpdate_AllowedFields(t *testing.T) {
 	assert.Equal(t, "new@example.com", app.ContactInfo)
 	assert.Equal(t, int64(7), *app.BoxID)
 }
-
-// ── delete ────────────────────────────────────────────────────────────────────
 
 func TestDelete_HappyPath(t *testing.T) {
 	repo := &mockApplicationRepo{
@@ -321,6 +322,16 @@ func TestDelete_InvalidID(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	r := httptest.NewRequest(http.MethodDelete, "/api/v1/applications/abc", nil)
+	newHandlerMux(repo).ServeHTTP(w, r)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestDelete_NegativeID(t *testing.T) {
+	repo := &mockApplicationRepo{}
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodDelete, "/api/v1/applications/-3", nil)
 	newHandlerMux(repo).ServeHTTP(w, r)
 
 	assert.Equal(t, http.StatusBadRequest, w.Code)

--- a/internal/api/application_handler_test.go
+++ b/internal/api/application_handler_test.go
@@ -1,0 +1,327 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/yandex-development-1-team/go/internal/models"
+)
+
+// mockApplicationRepo implements repository.ApplicationRepository for unit tests.
+type mockApplicationRepo struct {
+	createFn      func(ctx context.Context, req *models.ApplicationCreateRequest) (*models.Application, error)
+	listFn        func(ctx context.Context, filter models.ApplicationFilter) ([]models.Application, int, error)
+	getByIDFn     func(ctx context.Context, id int64) (*models.Application, error)
+	updateFn      func(ctx context.Context, id int64, req *models.ApplicationUpdateRequest) (*models.Application, error)
+	deleteFn      func(ctx context.Context, id int64) error
+}
+
+func (m *mockApplicationRepo) CreateApplication(ctx context.Context, req *models.ApplicationCreateRequest) (*models.Application, error) {
+	return m.createFn(ctx, req)
+}
+func (m *mockApplicationRepo) GetApplications(ctx context.Context, filter models.ApplicationFilter) ([]models.Application, int, error) {
+	return m.listFn(ctx, filter)
+}
+func (m *mockApplicationRepo) GetApplicationByID(ctx context.Context, id int64) (*models.Application, error) {
+	return m.getByIDFn(ctx, id)
+}
+func (m *mockApplicationRepo) UpdateApplication(ctx context.Context, id int64, req *models.ApplicationUpdateRequest) (*models.Application, error) {
+	return m.updateFn(ctx, id, req)
+}
+func (m *mockApplicationRepo) DeleteApplication(ctx context.Context, id int64) error {
+	return m.deleteFn(ctx, id)
+}
+
+func newHandlerMux(repo *mockApplicationRepo) *http.ServeMux {
+	mux := http.NewServeMux()
+	NewApplicationHandler(repo).RegisterRoutes(mux)
+	return mux
+}
+
+func sampleApp() *models.Application {
+	return &models.Application{
+		ID:          42,
+		Type:        models.ApplicationTypeBox,
+		Source:      models.ApplicationSourceManual,
+		Status:      models.ApplicationStatusQueue,
+		CustomerName: "Иван",
+		ContactInfo: "ivan@example.com",
+		CreatedAt:   time.Now(),
+		UpdatedAt:   time.Now(),
+	}
+}
+
+// ── create ────────────────────────────────────────────────────────────────────
+
+func TestCreate_HappyPath(t *testing.T) {
+	repo := &mockApplicationRepo{
+		createFn: func(_ context.Context, _ *models.ApplicationCreateRequest) (*models.Application, error) {
+			return sampleApp(), nil
+		},
+	}
+	body, _ := json.Marshal(models.ApplicationCreateRequest{
+		Type:         models.ApplicationTypeBox,
+		Source:       models.ApplicationSourceManual,
+		CustomerName: "Иван",
+		ContactInfo:  "ivan@example.com",
+	})
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/applications", bytes.NewReader(body))
+	newHandlerMux(repo).ServeHTTP(w, r)
+
+	assert.Equal(t, http.StatusCreated, w.Code)
+}
+
+func TestCreate_ValidationError(t *testing.T) {
+	repo := &mockApplicationRepo{}
+	body, _ := json.Marshal(models.ApplicationCreateRequest{
+		Type:   models.ApplicationTypeBox,
+		Source: models.ApplicationSourceManual,
+	})
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/applications", bytes.NewReader(body))
+	newHandlerMux(repo).ServeHTTP(w, r)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+// ── list ─────────────────────────────────────────────────────────────────────
+
+func TestList_HappyPath(t *testing.T) {
+	repo := &mockApplicationRepo{
+		listFn: func(_ context.Context, _ models.ApplicationFilter) ([]models.Application, int, error) {
+			return []models.Application{*sampleApp()}, 1, nil
+		},
+	}
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/api/v1/applications", nil)
+	newHandlerMux(repo).ServeHTTP(w, r)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp models.ApplicationListResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, 1, resp.Pagination.Total)
+	assert.Len(t, resp.Items, 1)
+}
+
+func TestList_EmptyReturnsEmptySlice(t *testing.T) {
+	repo := &mockApplicationRepo{
+		listFn: func(_ context.Context, _ models.ApplicationFilter) ([]models.Application, int, error) {
+			return nil, 0, nil
+		},
+	}
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/api/v1/applications", nil)
+	newHandlerMux(repo).ServeHTTP(w, r)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp models.ApplicationListResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.NotNil(t, resp.Items)
+	assert.Len(t, resp.Items, 0)
+}
+
+// ── getByID ───────────────────────────────────────────────────────────────────
+
+func TestGetByID_HappyPath(t *testing.T) {
+	repo := &mockApplicationRepo{
+		getByIDFn: func(_ context.Context, id int64) (*models.Application, error) {
+			app := sampleApp()
+			app.ID = id
+			return app, nil
+		},
+	}
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/api/v1/applications/42", nil)
+	newHandlerMux(repo).ServeHTTP(w, r)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var app models.Application
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &app))
+	assert.Equal(t, int64(42), app.ID)
+}
+
+func TestGetByID_NotFound(t *testing.T) {
+	repo := &mockApplicationRepo{
+		getByIDFn: func(_ context.Context, _ int64) (*models.Application, error) {
+			return nil, models.ErrApplicationNotFound
+		},
+	}
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/api/v1/applications/999", nil)
+	newHandlerMux(repo).ServeHTTP(w, r)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestGetByID_InvalidID(t *testing.T) {
+	repo := &mockApplicationRepo{}
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/api/v1/applications/abc", nil)
+	newHandlerMux(repo).ServeHTTP(w, r)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestGetByID_ZeroID(t *testing.T) {
+	repo := &mockApplicationRepo{}
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/api/v1/applications/0", nil)
+	newHandlerMux(repo).ServeHTTP(w, r)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+// ── update ────────────────────────────────────────────────────────────────────
+
+func TestUpdate_HappyPath(t *testing.T) {
+	status := models.ApplicationStatusInProgress
+	repo := &mockApplicationRepo{
+		updateFn: func(_ context.Context, _ int64, _ *models.ApplicationUpdateRequest) (*models.Application, error) {
+			app := sampleApp()
+			app.Status = status
+			return app, nil
+		},
+	}
+	body, _ := json.Marshal(models.ApplicationUpdateRequest{Status: &status})
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPut, "/api/v1/applications/42", bytes.NewReader(body))
+	newHandlerMux(repo).ServeHTTP(w, r)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var app models.Application
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &app))
+	assert.Equal(t, models.ApplicationStatusInProgress, app.Status)
+}
+
+func TestUpdate_NotFound(t *testing.T) {
+	status := models.ApplicationStatusDone
+	repo := &mockApplicationRepo{
+		updateFn: func(_ context.Context, _ int64, _ *models.ApplicationUpdateRequest) (*models.Application, error) {
+			return nil, models.ErrApplicationNotFound
+		},
+	}
+	body, _ := json.Marshal(models.ApplicationUpdateRequest{Status: &status})
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPut, "/api/v1/applications/999", bytes.NewReader(body))
+	newHandlerMux(repo).ServeHTTP(w, r)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestUpdate_NoFields(t *testing.T) {
+	repo := &mockApplicationRepo{}
+	body, _ := json.Marshal(models.ApplicationUpdateRequest{})
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPut, "/api/v1/applications/42", bytes.NewReader(body))
+	newHandlerMux(repo).ServeHTTP(w, r)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestUpdate_InvalidStatus(t *testing.T) {
+	repo := &mockApplicationRepo{}
+	invalidStatus := models.ApplicationStatus("unknown")
+	body, _ := json.Marshal(models.ApplicationUpdateRequest{Status: &invalidStatus})
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPut, "/api/v1/applications/42", bytes.NewReader(body))
+	newHandlerMux(repo).ServeHTTP(w, r)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestUpdate_InvalidID(t *testing.T) {
+	repo := &mockApplicationRepo{}
+	body, _ := json.Marshal(models.ApplicationUpdateRequest{})
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPut, "/api/v1/applications/abc", bytes.NewReader(body))
+	newHandlerMux(repo).ServeHTTP(w, r)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestUpdate_AllowedFields(t *testing.T) {
+	contact := "new@example.com"
+	boxID := int64(7)
+	repo := &mockApplicationRepo{
+		updateFn: func(_ context.Context, _ int64, req *models.ApplicationUpdateRequest) (*models.Application, error) {
+			app := sampleApp()
+			app.ContactInfo = *req.ContactInfo
+			app.BoxID = req.BoxID
+			return app, nil
+		},
+	}
+	body, _ := json.Marshal(models.ApplicationUpdateRequest{ContactInfo: &contact, BoxID: &boxID})
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPut, "/api/v1/applications/42", bytes.NewReader(body))
+	newHandlerMux(repo).ServeHTTP(w, r)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var app models.Application
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &app))
+	assert.Equal(t, "new@example.com", app.ContactInfo)
+	assert.Equal(t, int64(7), *app.BoxID)
+}
+
+// ── delete ────────────────────────────────────────────────────────────────────
+
+func TestDelete_HappyPath(t *testing.T) {
+	repo := &mockApplicationRepo{
+		deleteFn: func(_ context.Context, _ int64) error {
+			return nil
+		},
+	}
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodDelete, "/api/v1/applications/42", nil)
+	newHandlerMux(repo).ServeHTTP(w, r)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), "message")
+}
+
+func TestDelete_NotFound(t *testing.T) {
+	repo := &mockApplicationRepo{
+		deleteFn: func(_ context.Context, _ int64) error {
+			return models.ErrApplicationNotFound
+		},
+	}
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodDelete, "/api/v1/applications/999", nil)
+	newHandlerMux(repo).ServeHTTP(w, r)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestDelete_InvalidID(t *testing.T) {
+	repo := &mockApplicationRepo{}
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodDelete, "/api/v1/applications/abc", nil)
+	newHandlerMux(repo).ServeHTTP(w, r)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}

--- a/internal/database/repository/application_repository.go
+++ b/internal/database/repository/application_repository.go
@@ -2,6 +2,8 @@ package repository
 
 import (
 	"context"
+	"database/sql"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -71,6 +73,98 @@ func (r *ApplicationRepo) GetApplications(ctx context.Context, filter models.App
 		return nil, 0, checkError(operation, err)
 	}
 	return apps, total, nil
+}
+
+const selectApplicationByIDQuery = `
+	SELECT id, type, source, status, customer_name, contact_info,
+	       project_name, box_id, special_project_id, manager_id, created_at, updated_at
+	FROM applications
+	WHERE id = $1`
+
+func (r *ApplicationRepo) GetApplicationByID(ctx context.Context, id int64) (*models.Application, error) {
+	const operation = "get_application_by_id"
+
+	var app models.Application
+	err := r.db.QueryRowxContext(ctx, selectApplicationByIDQuery, id).StructScan(&app)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, models.ErrApplicationNotFound
+		}
+		return nil, checkError(operation, err)
+	}
+	return &app, nil
+}
+
+func (r *ApplicationRepo) UpdateApplication(ctx context.Context, id int64, req *models.ApplicationUpdateRequest) (*models.Application, error) {
+	const operation = "update_application"
+
+	if req == nil {
+		return nil, models.ErrInvalidInput
+	}
+
+	var setClauses []string
+	var args []interface{}
+
+	addSet := func(col string, val interface{}) {
+		args = append(args, val)
+		setClauses = append(setClauses, fmt.Sprintf("%s = $%d", col, len(args)))
+	}
+
+	if req.Status != nil {
+		if !req.Status.Valid() {
+			return nil, models.ErrInvalidInput
+		}
+		addSet("status", *req.Status)
+	}
+	if req.ContactInfo != nil {
+		addSet("contact_info", *req.ContactInfo)
+	}
+	if req.BoxID != nil {
+		addSet("box_id", *req.BoxID)
+	}
+	if req.SpecialProjectID != nil {
+		addSet("special_project_id", *req.SpecialProjectID)
+	}
+
+	if len(setClauses) == 0 {
+		return nil, models.ErrInvalidInput
+	}
+
+	args = append(args, id)
+	query := fmt.Sprintf(`
+		UPDATE applications
+		SET %s, updated_at = NOW()
+		WHERE id = $%d
+		RETURNING id, type, source, status, customer_name, contact_info,
+		          project_name, box_id, special_project_id, manager_id, created_at, updated_at`,
+		strings.Join(setClauses, ", "), len(args))
+
+	var app models.Application
+	err := r.db.QueryRowxContext(ctx, query, args...).StructScan(&app)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, models.ErrApplicationNotFound
+		}
+		return nil, checkError(operation, err)
+	}
+	return &app, nil
+}
+
+func (r *ApplicationRepo) DeleteApplication(ctx context.Context, id int64) error {
+	const operation = "delete_application"
+
+	result, err := r.db.ExecContext(ctx, `DELETE FROM applications WHERE id = $1`, id)
+	if err != nil {
+		return checkError(operation, err)
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return checkError(operation, err)
+	}
+	if affected == 0 {
+		return models.ErrApplicationNotFound
+	}
+	return nil
 }
 
 func buildApplicationWhere(f models.ApplicationFilter) (string, []interface{}) {

--- a/internal/database/repository/application_repository.go
+++ b/internal/database/repository/application_repository.go
@@ -98,7 +98,7 @@ func (r *ApplicationRepo) GetApplicationByID(ctx context.Context, id int64) (*mo
 func (r *ApplicationRepo) UpdateApplication(ctx context.Context, id int64, req *models.ApplicationUpdateRequest) (*models.Application, error) {
 	const operation = "update_application"
 
-	if req == nil {
+	if req == nil || !req.HasUpdates() {
 		return nil, models.ErrInvalidInput
 	}
 
@@ -111,9 +111,6 @@ func (r *ApplicationRepo) UpdateApplication(ctx context.Context, id int64, req *
 	}
 
 	if req.Status != nil {
-		if !req.Status.Valid() {
-			return nil, models.ErrInvalidInput
-		}
 		addSet("status", *req.Status)
 	}
 	if req.ContactInfo != nil {
@@ -124,10 +121,6 @@ func (r *ApplicationRepo) UpdateApplication(ctx context.Context, id int64, req *
 	}
 	if req.SpecialProjectID != nil {
 		addSet("special_project_id", *req.SpecialProjectID)
-	}
-
-	if len(setClauses) == 0 {
-		return nil, models.ErrInvalidInput
 	}
 
 	args = append(args, id)

--- a/internal/database/repository/application_repository_test.go
+++ b/internal/database/repository/application_repository_test.go
@@ -129,3 +129,129 @@ func TestApplicationRepo_GetApplications(t *testing.T) {
 		}
 	})
 }
+
+func TestApplicationRepo_GetApplicationByID(t *testing.T) {
+	appRepo := NewApplicationRepository(db)
+	ctx := context.Background()
+
+	created, err := appRepo.CreateApplication(ctx, &models.ApplicationCreateRequest{
+		Type:         models.ApplicationTypeBox,
+		Source:       models.ApplicationSourceManual,
+		CustomerName: "GetByID User",
+		ContactInfo:  "getbyid@example.com",
+	})
+	require.NoError(t, err)
+
+	t.Run("happy path — existing id", func(t *testing.T) {
+		app, err := appRepo.GetApplicationByID(ctx, created.ID)
+		require.NoError(t, err)
+		assert.Equal(t, created.ID, app.ID)
+		assert.Equal(t, models.ApplicationTypeBox, app.Type)
+		assert.Equal(t, "GetByID User", app.CustomerName)
+		assert.Equal(t, "getbyid@example.com", app.ContactInfo)
+	})
+
+	t.Run("not found — unknown id", func(t *testing.T) {
+		_, err := appRepo.GetApplicationByID(ctx, -1)
+		assert.ErrorIs(t, err, models.ErrApplicationNotFound)
+	})
+}
+
+func TestApplicationRepo_UpdateApplication(t *testing.T) {
+	appRepo := NewApplicationRepository(db)
+	ctx := context.Background()
+
+	created, err := appRepo.CreateApplication(ctx, &models.ApplicationCreateRequest{
+		Type:         models.ApplicationTypeSpecialProject,
+		Source:       models.ApplicationSourceManual,
+		CustomerName: "Update User",
+		ContactInfo:  "update@example.com",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, models.ApplicationStatusQueue, created.Status)
+
+	t.Run("DoD: status changes and is visible in list", func(t *testing.T) {
+		newStatus := models.ApplicationStatusInProgress
+		updated, err := appRepo.UpdateApplication(ctx, created.ID, &models.ApplicationUpdateRequest{
+			Status: &newStatus,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, models.ApplicationStatusInProgress, updated.Status)
+		assert.Equal(t, created.ID, updated.ID)
+
+		fetched, err := appRepo.GetApplicationByID(ctx, created.ID)
+		require.NoError(t, err)
+		assert.Equal(t, models.ApplicationStatusInProgress, fetched.Status)
+	})
+
+	t.Run("DoD: contact_info update", func(t *testing.T) {
+		newContact := "updated@example.com"
+		updated, err := appRepo.UpdateApplication(ctx, created.ID, &models.ApplicationUpdateRequest{
+			ContactInfo: &newContact,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "updated@example.com", updated.ContactInfo)
+	})
+
+	t.Run("DoD: box_id update visible in card", func(t *testing.T) {
+		boxID := int64(1)
+		updated, err := appRepo.UpdateApplication(ctx, created.ID, &models.ApplicationUpdateRequest{
+			BoxID: &boxID,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, int64(1), *updated.BoxID)
+
+		fetched, err := appRepo.GetApplicationByID(ctx, created.ID)
+		require.NoError(t, err)
+		assert.Equal(t, int64(1), *fetched.BoxID)
+	})
+
+	t.Run("not found — unknown id", func(t *testing.T) {
+		newStatus := models.ApplicationStatusDone
+		_, err := appRepo.UpdateApplication(ctx, -1, &models.ApplicationUpdateRequest{
+			Status: &newStatus,
+		})
+		assert.ErrorIs(t, err, models.ErrApplicationNotFound)
+	})
+
+	t.Run("invalid input — no fields", func(t *testing.T) {
+		_, err := appRepo.UpdateApplication(ctx, created.ID, &models.ApplicationUpdateRequest{})
+		assert.ErrorIs(t, err, models.ErrInvalidInput)
+	})
+
+	t.Run("invalid input — nil request", func(t *testing.T) {
+		_, err := appRepo.UpdateApplication(ctx, created.ID, nil)
+		assert.ErrorIs(t, err, models.ErrInvalidInput)
+	})
+}
+
+func TestApplicationRepo_DeleteApplication(t *testing.T) {
+	appRepo := NewApplicationRepository(db)
+	ctx := context.Background()
+
+	created, err := appRepo.CreateApplication(ctx, &models.ApplicationCreateRequest{
+		Type:         models.ApplicationTypeBox,
+		Source:       models.ApplicationSourceTelegramBot,
+		CustomerName: "Delete User",
+		ContactInfo:  "delete@example.com",
+	})
+	require.NoError(t, err)
+
+	t.Run("happy path — existing application deleted", func(t *testing.T) {
+		err := appRepo.DeleteApplication(ctx, created.ID)
+		require.NoError(t, err)
+
+		_, err = appRepo.GetApplicationByID(ctx, created.ID)
+		assert.ErrorIs(t, err, models.ErrApplicationNotFound)
+	})
+
+	t.Run("not found — already deleted", func(t *testing.T) {
+		err := appRepo.DeleteApplication(ctx, created.ID)
+		assert.ErrorIs(t, err, models.ErrApplicationNotFound)
+	})
+
+	t.Run("not found — unknown id", func(t *testing.T) {
+		err := appRepo.DeleteApplication(ctx, -1)
+		assert.ErrorIs(t, err, models.ErrApplicationNotFound)
+	})
+}

--- a/internal/database/repository/decorator.go
+++ b/internal/database/repository/decorator.go
@@ -92,6 +92,10 @@ func checkError(operation string, err error) error {
 		logger.Info("user_not_found", zap.Error(err), zap.String("operation", operation))
 		return models.ErrUserNotFound
 	}
+	if errors.Is(err, models.ErrApplicationNotFound) {
+		logger.Info("application_not_found", zap.Error(err), zap.String("operation", operation))
+		return models.ErrApplicationNotFound
+	}
 	if errors.Is(err, context.Canceled) {
 		logger.Info("canceled_by_context", zap.Error(err), zap.String("operation", operation))
 		return models.ErrRequestCanceled

--- a/internal/database/repository/interfaces.go
+++ b/internal/database/repository/interfaces.go
@@ -27,6 +27,9 @@ type BookingRepository interface {
 type ApplicationRepository interface {
 	CreateApplication(ctx context.Context, req *models.ApplicationCreateRequest) (*models.Application, error)
 	GetApplications(ctx context.Context, filter models.ApplicationFilter) ([]models.Application, int, error)
+	GetApplicationByID(ctx context.Context, id int64) (*models.Application, error)
+	UpdateApplication(ctx context.Context, id int64, req *models.ApplicationUpdateRequest) (*models.Application, error)
+	DeleteApplication(ctx context.Context, id int64) error
 }
 
 // BoxSolutionRepository — коробочные решения (services).

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -20,7 +20,8 @@ var (
 	ErrValidation             = errors.New("validation error")
 	ErrForbidden              = errors.New("forbidden")
 	ErrCache                  = errors.New("cache error")
-	ErrEmailAlreadyExist      = errors.New("user already exist")
+	ErrEmailAlreadyExist       = errors.New("user already exist")
+	ErrApplicationNotFound     = errors.New("application not found")
 )
 
 // RefreshToken — refresh-токен для аутентификации.
@@ -183,4 +184,11 @@ type Pagination struct {
 type ApplicationListResponse struct {
 	Items      []Application `json:"items"`
 	Pagination Pagination    `json:"pagination"`
+}
+
+type ApplicationUpdateRequest struct {
+	Status           *ApplicationStatus `json:"status,omitempty"`
+	ContactInfo      *string            `json:"contact_info,omitempty"`
+	BoxID            *int64             `json:"box_id,omitempty"`
+	SpecialProjectID *int64             `json:"special_project_id,omitempty"`
 }

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -20,8 +20,8 @@ var (
 	ErrValidation             = errors.New("validation error")
 	ErrForbidden              = errors.New("forbidden")
 	ErrCache                  = errors.New("cache error")
-	ErrEmailAlreadyExist       = errors.New("user already exist")
-	ErrApplicationNotFound     = errors.New("application not found")
+	ErrEmailAlreadyExist      = errors.New("user already exist")
+	ErrApplicationNotFound    = errors.New("application not found")
 )
 
 // RefreshToken — refresh-токен для аутентификации.
@@ -191,4 +191,8 @@ type ApplicationUpdateRequest struct {
 	ContactInfo      *string            `json:"contact_info,omitempty"`
 	BoxID            *int64             `json:"box_id,omitempty"`
 	SpecialProjectID *int64             `json:"special_project_id,omitempty"`
+}
+
+func (r *ApplicationUpdateRequest) HasUpdates() bool {
+	return r.Status != nil || r.ContactInfo != nil || r.BoxID != nil || r.SpecialProjectID != nil
 }


### PR DESCRIPTION
## Что сделано

Реализованы три эндпоинта для работы с заявками:

- **GET /api/v1/applications/{id}** — получение полной карточки заявки
- **PUT /api/v1/applications/{id}** — обновление статуса, контактов, box_id, special_project_id
- **DELETE /api/v1/applications/{id}** — удаление заявки (hard delete)

## Изменения

- Добавлены модели `ApplicationUpdateRequest` с методом `HasUpdates()` и ошибка `ErrApplicationNotFound`
- Расширен интерфейс `ApplicationRepository` тремя новыми методами
- Реализованы методы репозитория: SELECT по id, динамический UPDATE RETURNING, DELETE с проверкой affected rows
- Добавлены HTTP-обработчики с валидацией входных данных

## Тесты

- 19 unit-тестов обработчиков (mock-based, httptest)
- 11 integration-тестов репозитория (testcontainers + PostgreSQL)

Все тесты зелёные.

Closes #81