### PR TITLE
Feat/fix resources pages

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1464,9 +1464,6 @@
           },
           "401": {
             "$ref": "#/components/responses/UnauthorizedError"
-          },
-          "401": {
-            "$ref": "#/components/responses/UnauthorizedError"
           }
         }
       }
@@ -1904,7 +1901,7 @@
                 "schema": {
                   "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/ResourcePageSummary"
+                    "$ref": "#/components/schemas/ResourcePage"
                   }
                 }
               }
@@ -1942,9 +1939,6 @@
                 }
               }
             }
-          },
-          "404": {
-            "$ref": "#/components/responses/NotFoundError"
           }
         }
       },
@@ -2024,21 +2018,10 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "message": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "message"
-                  ]
+                  "$ref": "#/components/schemas/ResourcePage"
                 }
               }
             }
-          },
-          "404": {
-            "$ref": "#/components/responses/NotFoundError"
           }
         }
       }

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1985,6 +1985,34 @@
             "$ref": "#/components/responses/NotFoundError"
           }
         }
+      },
+      "delete": {
+        "summary": "Очистить ресурсную страницу",
+        "tags": [
+          "resources"
+        ],
+        "parameters": [
+          {
+            "name": "slug",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Ресурсная страница очищена",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ResourcePage"
+                }
+              }
+            }
+          }
+        }
       }
     },
     "/api/v1/resources/{slug}/{id}": {

--- a/internal/api/handlers/resource_page.go
+++ b/internal/api/handlers/resource_page.go
@@ -1,16 +1,16 @@
 package handlers
 
 import (
-	"errors"
-	"fmt"
 	"log"
 	"net/http"
-	"net/url"
-	"strings"
+	"time"
 
 	"github.com/gin-gonic/gin"
+	"go.uber.org/zap"
 
+	"github.com/yandex-development-1-team/go/internal/apierrors"
 	"github.com/yandex-development-1-team/go/internal/dto"
+	"github.com/yandex-development-1-team/go/internal/logger"
 	"github.com/yandex-development-1-team/go/internal/models"
 	"github.com/yandex-development-1-team/go/internal/service"
 )
@@ -23,197 +23,145 @@ func NewResourcePageHandler(service *service.ResourcePageService) *ResourcePageH
 	return &ResourcePageHandler{service: service}
 }
 
-func (h *ResourcePageHandler) ListResourcePages(c *gin.Context) {
+func (h *ResourcePageHandler) GetAll(c *gin.Context) {
 	ctx := c.Request.Context()
-	summaries, err := h.service.GetAllSummaries(ctx)
+
+	pages, err := h.service.GetAllResourcePages(ctx)
 	if err != nil {
-		log.Printf("ERROR: failed to get resource page summaries: %v", err)
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal Server Error"})
+		logger.Error("GetAll", zap.Error(err))
+		apierrors.WriteErrorMessagesGin(c, http.StatusInternalServerError, []string{"Internal Server Error"})
 		return
 	}
 
-	c.JSON(http.StatusOK, summaries)
+	response := make([]dto.ResourcePageResponse, 0, len(pages))
+	for _, p := range pages {
+		response = append(response, toResourcePageResponse(p))
+	}
+
+	c.JSON(http.StatusOK, response)
 }
 
-func (h *ResourcePageHandler) GetResourcePage(c *gin.Context) {
+func (h *ResourcePageHandler) GetBySlug(c *gin.Context) {
 	slug := c.Param("slug")
-	if slug == "" {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "Missing slug"})
-		return
-	}
 
 	ctx := c.Request.Context()
 	page, err := h.service.GetResourcePage(ctx, slug)
 	if err != nil {
-		if errors.Is(err, models.ErrResourcePageNotFound) {
-			c.JSON(http.StatusNotFound, gin.H{"error": "Not Found"})
-			return
-		}
-		log.Printf("ERROR: failed to get resource page %s: %v", slug, err)
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal Server Error"})
+		apierrors.WriteErrorGin(c, err)
 		return
 	}
 
-	c.JSON(http.StatusOK, toAPIResponse(page))
+	c.JSON(http.StatusOK, toResourcePageResponse(*page))
 }
 
-func (h *ResourcePageHandler) UpdateResourcePage(c *gin.Context) {
+func (h *ResourcePageHandler) GetPublicBySlug(c *gin.Context) {
 	slug := c.Param("slug")
-	if slug == "" {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "Missing slug"})
-		return
-	}
-
-	var updateReq dto.ResourcePageUpdateRequest
-	if err := c.ShouldBindJSON(&updateReq); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid JSON"})
-		return
-	}
-
-	ctx := c.Request.Context()
-	newPageData, err := toDomainFromAPIUpdateRequest(&updateReq)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("failed to parse update request: %v", err)})
-		return
-	}
-
-	updatedPage, err := h.service.UpdateResourcePage(ctx, slug, newPageData)
-	if err != nil {
-		if errors.Is(err, models.ErrResourcePageNotFound) {
-			c.JSON(http.StatusNotFound, gin.H{"error": "Not Found"})
-			return
-		}
-		if strings.Contains(err.Error(), "validation error:") {
-			c.JSON(http.StatusBadRequest, gin.H{"field_errors": gin.H{"links": err.Error()}})
-			return
-		}
-		log.Printf("ERROR: failed to update resource page %s: %v", slug, err)
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal Server Error"})
-		return
-	}
-
-	c.JSON(http.StatusOK, toAPIResponse(updatedPage))
-}
-
-func (h *ResourcePageHandler) GetPublicResourcePage(c *gin.Context) {
-	slug := c.Param("slug")
-	if slug == "" {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "Missing slug"})
-		return
-	}
 
 	ctx := c.Request.Context()
 	page, err := h.service.GetResourcePage(ctx, slug)
 	if err != nil {
-		if errors.Is(err, models.ErrResourcePageNotFound) {
-			c.JSON(http.StatusNotFound, gin.H{"error": "Not Found"})
-			return
-		}
-		log.Printf("ERROR: failed to get public resource page %s: %v", slug, err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal Server Error"})
 		return
 	}
 
-	c.JSON(http.StatusOK, toAPIResponsePublic(page))
+	c.JSON(http.StatusOK, toResourcePagePublicResponse(*page))
+}
+
+func (h *ResourcePageHandler) Update(c *gin.Context) {
+	slug := c.Param("slug")
+
+	var req dto.ResourcePageUpdateRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		apierrors.WriteErrorMessagesGin(c, http.StatusBadRequest, []string{"Некорректные данные"})
+		return
+	}
+
+	ctx := c.Request.Context()
+	updatedPage, err := h.service.UpdateResourcePage(ctx, slug, toDomainUpdateRequest(req))
+	if err != nil {
+		logger.Error("Update", zap.Error(err))
+		apierrors.WriteErrorGin(c, err)
+		return
+	}
+
+	c.JSON(http.StatusOK, toResourcePageResponse(*updatedPage))
 }
 
 func (h *ResourcePageHandler) DeleteLink(c *gin.Context) {
 	slug := c.Param("slug")
 	id := c.Param("id")
 
-	if slug == "" || id == "" {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "Slug or Link ID cannot be empty"})
-		return
-	}
-
 	ctx := c.Request.Context()
-	err := h.service.DeleteLink(ctx, slug, id)
+	page, err := h.service.DeleteResourcePageLink(ctx, slug, id)
 	if err != nil {
-		if errors.Is(err, models.ErrResourcePageNotFound) {
-			c.JSON(http.StatusNotFound, gin.H{"error": "Page Not Found"})
-			return
-		}
-		if strings.Contains(err.Error(), "not found in page") {
-			c.JSON(http.StatusNotFound, gin.H{"error": "Link Not Found"})
-			return
-		}
-		log.Printf("ERROR: failed to delete link %s from page %s: %v", id, slug, err)
+		log.Printf("ERROR: failed to delete link %s from %s: %v", id, slug, err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal Server Error"})
 		return
 	}
 
-	c.Status(http.StatusNoContent)
+	c.JSON(http.StatusOK, toResourcePageResponse(*page))
 }
 
-func toAPIResponse(domainModel *models.ResourcePage) *dto.ResourcePageResponse {
-	if domainModel == nil {
-		return nil
+func (h *ResourcePageHandler) Delete(c *gin.Context) {
+	slug := c.Param("slug")
+
+	ctx := c.Request.Context()
+	updatedPage, err := h.service.ClearResourcePage(ctx, slug)
+	logger.Error("Delete", zap.Error(err))
+	if err != nil {
+		apierrors.WriteErrorGin(c, err)
+		return
 	}
 
-	var contentPtr *string
-	if domainModel.Content != "" {
-		contentPtr = &domainModel.Content
-	}
-
-	var linksPtr *[]models.ResourcePageLink
-	if len(domainModel.Links) > 0 {
-		linksPtr = &domainModel.Links
-	}
-
-	return &dto.ResourcePageResponse{
-		Title:   domainModel.Title,
-		Content: contentPtr,
-		Links:   linksPtr,
-	}
+	c.JSON(http.StatusOK, toResourcePageResponse(*updatedPage))
 }
 
-func toAPIResponsePublic(domainModel *models.ResourcePage) *dto.ResourcePageResponsePublic {
-	if domainModel == nil {
-		return nil
+func toResourcePageResponse(p models.ResourcePage) dto.ResourcePageResponse {
+	links := make([]dto.ResourcePageLink, 0, len(p.Links))
+	for _, l := range p.Links {
+		links = append(links, dto.ResourcePageLink{
+			ID:    l.ID,
+			Title: l.Title,
+			URL:   l.URL,
+		})
 	}
-
-	var contentPtr *string
-	if domainModel.Content != "" {
-		contentPtr = &domainModel.Content
-	}
-
-	var linksPtr *[]models.ResourcePageLink
-	if len(domainModel.Links) > 0 {
-		linksPtr = &domainModel.Links
-	}
-
-	return &dto.ResourcePageResponsePublic{
-		Title:   domainModel.Title,
-		Content: contentPtr,
-		Links:   linksPtr,
+	return dto.ResourcePageResponse{
+		Slug:      p.Slug,
+		Title:     p.Title,
+		Content:   p.Content,
+		Links:     links,
+		UpdatedAt: p.UpdatedAt.Format(time.RFC3339),
 	}
 }
 
-func toDomainFromAPIUpdateRequest(apiReq *dto.ResourcePageUpdateRequest) (*models.ResourcePage, error) {
-	if apiReq == nil {
-		return nil, nil
+func toDomainUpdateRequest(req dto.ResourcePageUpdateRequest) models.ResourcePage {
+	links := make([]models.ResourcePageLink, 0, len(req.Links))
+	for _, l := range req.Links {
+		links = append(links, models.ResourcePageLink{
+			ID:    l.ID,
+			Title: l.Title,
+			URL:   l.URL,
+		})
 	}
-
-	domainUpdate := &models.ResourcePage{}
-
-	if apiReq.Title != nil {
-		domainUpdate.Title = *apiReq.Title
+	return models.ResourcePage{
+		Title:   req.Title,
+		Content: req.Content,
+		Links:   links,
 	}
-	if apiReq.Content != nil {
-		domainUpdate.Content = *apiReq.Content
-	}
-	if apiReq.Links != nil {
-		for _, newLink := range *apiReq.Links {
-			parsedURL, err := url.ParseRequestURI(newLink.URL)
-			if err != nil || parsedURL.Scheme == "" || parsedURL.Host == "" {
-				return nil, fmt.Errorf("validation error: invalid URI '%s' for link ID '%s'", newLink.URL, newLink.ID)
-			}
-		}
+}
 
-		newLinks := make([]models.ResourcePageLink, len(*apiReq.Links))
-		copy(newLinks, *apiReq.Links)
-		domainUpdate.Links = newLinks
+func toResourcePagePublicResponse(p models.ResourcePage) dto.ResourcePagePublicResponse {
+	links := make([]dto.ResourcePageLink, 0, len(p.Links))
+	for _, l := range p.Links {
+		links = append(links, dto.ResourcePageLink{
+			ID:    l.ID,
+			Title: l.Title,
+			URL:   l.URL,
+		})
 	}
-
-	return domainUpdate, nil
+	return dto.ResourcePagePublicResponse{
+		Title:   p.Title,
+		Content: p.Content,
+		Links:   links,
+	}
 }

--- a/internal/api/middleware/auth.go
+++ b/internal/api/middleware/auth.go
@@ -43,13 +43,13 @@ func Auth(jwtSecret []byte) gin.HandlerFunc {
 		)
 
 		if err != nil || !token.Valid {
-			c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": models.ErrValidation})
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": models.ErrValidation})
 			return
 		}
 
 		claims, ok := token.Claims.(*service.AccessClaims)
 		if !ok {
-			c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": models.ErrValidation})
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": models.ErrValidation})
 			return
 		}
 

--- a/internal/api/server/routes.go
+++ b/internal/api/server/routes.go
@@ -23,7 +23,7 @@ func SetupRoutes(router *gin.Engine, jwtSecret []byte, authHandler *handlers.Aut
 			setupResourcesRoutes(protected, recPageHandler)
 		}
 		public := apiV1.Group("/public")
-		public.GET("/resources/:slug", recPageHandler.GetPublicResourcePage)
+		public.GET("/resources/:slug", recPageHandler.GetPublicBySlug)
 	}
 }
 
@@ -85,9 +85,10 @@ func setupUserRoutes(rg *gin.RouterGroup, h *handlers.UserHandler) {
 func setupResourcesRoutes(rg *gin.RouterGroup, h *handlers.ResourcePageHandler) {
 	resources := rg.Group("/resources")
 	{
-		resources.GET("/", h.ListResourcePages)
-		resources.GET("/:slug", h.GetResourcePage)
-		resources.PUT("/:slug", h.UpdateResourcePage)
-		resources.DELETE("/:slug", h.DeleteLink)
+		resources.GET("/", h.GetAll)
+		resources.GET("/:slug", h.GetBySlug)
+		resources.PUT("/:slug", h.Update)
+		resources.DELETE("/:slug/:id", h.DeleteLink)
+		resources.DELETE("/:slug", h.Delete)
 	}
 }

--- a/internal/dto/resource_page.go
+++ b/internal/dto/resource_page.go
@@ -8,13 +8,13 @@ import (
 type ResourcePageLink struct {
 	ID    string `json:"id"`
 	Title string `json:"title"`
-	URL   string `json:"url"`
+	URL   string `json:"url" binding:"required,url"`
 }
 
 type ResourcePageUpdateRequest struct {
 	Title   string             `json:"title"`
 	Content string             `json:"content"`
-	Links   []ResourcePageLink `json:"links"`
+	Links   []ResourcePageLink `json:"links" binding:"dive"`
 }
 
 type ResourcePageResponse struct {

--- a/internal/dto/resource_page.go
+++ b/internal/dto/resource_page.go
@@ -1,28 +1,40 @@
 package dto
 
-import "github.com/yandex-development-1-team/go/internal/models"
+import (
+	"encoding/json"
+	"time"
+)
+
+type ResourcePageLink struct {
+	ID    string `json:"id"`
+	Title string `json:"title"`
+	URL   string `json:"url"`
+}
 
 type ResourcePageUpdateRequest struct {
-	Slug    string                     `json:"slug,omitempty"`
-	Title   *string                    `json:"title,omitempty"`
-	Content *string                    `json:"content,omitempty"`
-	Links   *[]models.ResourcePageLink `json:"links,omitempty"`
+	Title   string             `json:"title"`
+	Content string             `json:"content"`
+	Links   []ResourcePageLink `json:"links"`
 }
 
 type ResourcePageResponse struct {
-	Title   string                     `json:"title,omitempty"`
-	Content *string                    `json:"content,omitempty"`
-	Links   *[]models.ResourcePageLink `json:"links,omitempty"`
+	Slug      string             `json:"slug"`
+	Title     string             `json:"title"`
+	Content   string             `json:"content"`
+	Links     []ResourcePageLink `json:"links"`
+	UpdatedAt string             `json:"updated_at"`
 }
 
-type ResourcePageResponsePublic struct {
-	Title   string                     `json:"title,omitempty"`
-	Content *string                    `json:"content,omitempty"`
-	Links   *[]models.ResourcePageLink `json:"links,omitempty"`
+type ResourcePageDB struct {
+	Slug      string          `db:"slug"`
+	Title     string          `db:"title"`
+	Content   string          `db:"content"`
+	Links     json.RawMessage `db:"links"`
+	UpdatedAt time.Time       `db:"updated_at"`
 }
 
-type ResourcePagePublic struct {
-	Title   string                    `json:"title"`
-	Content string                    `json:"content"`
-	Links   []models.ResourcePageLink `json:"links"`
+type ResourcePagePublicResponse struct {
+	Title   string             `json:"title"`
+	Content string             `json:"content"`
+	Links   []ResourcePageLink `json:"links"`
 }

--- a/internal/models/resource_page.go
+++ b/internal/models/resource_page.go
@@ -1,7 +1,6 @@
 package models
 
 import (
-	"encoding/json"
 	"errors"
 	"time"
 )
@@ -15,19 +14,10 @@ type ResourcePageLink struct {
 }
 
 type ResourcePage struct {
-	Slug      string             `json:"slug"`
-	Title     string             `json:"title"`
-	Content   string             `json:"content"`
-	Links     []ResourcePageLink `json:"-"`
-	LinksJSON json.RawMessage    `json:"links"`
-	UpdatedAt string             `json:"updated_at"`
-}
-
-type ResourcePageDB struct {
-	Slug      string          `db:"slug"`
-	Title     string          `db:"title"`
-	Content   *string         `db:"content"`
-	LinksJSON json.RawMessage `db:"links"`
-	CreatedAt time.Time       `db:"created_at"`
-	UpdatedAt time.Time       `db:"updated_at"`
+	Slug      string
+	Title     string
+	Content   string
+	Links     []ResourcePageLink
+	CreatedAt time.Time
+	UpdatedAt time.Time
 }

--- a/internal/repository/interfaces.go
+++ b/internal/repository/interfaces.go
@@ -90,11 +90,11 @@ type TxRepository interface {
 }
 
 type ResourcePageRepository interface {
+	GetAll(ctx context.Context) ([]models.ResourcePage, error)
 	GetBySlug(ctx context.Context, slug string) (*models.ResourcePage, error)
-	GetBySlugTx(ctx context.Context, queryable Queryable, slug string, lockForUpdate bool) (*models.ResourcePage, error)
-	UpdatePageContentAndLinksTx(ctx context.Context, tx *sqlx.Tx, slug string, title string, content string, links []models.ResourcePageLink) error
-	GetAllSummaries(ctx context.Context) ([]*models.ResourcePage, error)
-	BeginTx(ctx context.Context) (*sqlx.Tx, error)
+	Update(ctx context.Context, slug string, page models.ResourcePage) (*models.ResourcePage, error)
+	Clear(ctx context.Context, slug string) (*models.ResourcePage, error)
+	DeleteLink(ctx context.Context, slug string, id string) (*models.ResourcePage, error)
 }
 
 type Queryable interface {

--- a/internal/repository/postgres/booking_repository_test.go
+++ b/internal/repository/postgres/booking_repository_test.go
@@ -24,11 +24,12 @@ import (
 )
 
 var (
-	db          *sqlx.DB
-	repo        *BookingRepo
-	repoUser    *TelegramUserRepo
-	repoSession *pgSessionRepo
-	boxRepo     *BoxSolutionRepo
+	db               *sqlx.DB
+	repo             *BookingRepo
+	repoUser         *TelegramUserRepo
+	repoSession      *pgSessionRepo
+	boxRepo          *BoxSolutionRepo
+	resourcePageRepo *ResourcePageRepository
 )
 
 func mustParseTime(layout, value string) *time.Time {
@@ -43,7 +44,7 @@ func TestMain(m *testing.M) {
 	logger.NewLogger("dev", "debug")
 	metrics.Initialize(config.Config{Environment: "test", HostName: "test"})
 
-	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 180*time.Second)
 	defer cancel()
 
 	container, err := startContainer()
@@ -64,6 +65,7 @@ func TestMain(m *testing.M) {
 	repoUser = NewTelegramUserRepository(db)
 	repoSession = NewSessionRepository(db)
 	boxRepo = NewBoxSolutionRepo(db)
+	resourcePageRepo = NewResourcePageRepo(db)
 
 	code := m.Run()
 

--- a/internal/repository/postgres/resource_page.go
+++ b/internal/repository/postgres/resource_page.go
@@ -2,16 +2,14 @@ package postgres
 
 import (
 	"context"
-	"database/sql"
 	"encoding/json"
-	"errors"
 	"fmt"
-	"time"
 
+	"github.com/google/uuid"
 	"github.com/jmoiron/sqlx"
 
+	"github.com/yandex-development-1-team/go/internal/dto"
 	"github.com/yandex-development-1-team/go/internal/models"
-	"github.com/yandex-development-1-team/go/internal/repository"
 )
 
 type ResourcePageRepository struct {
@@ -22,147 +20,119 @@ func NewResourcePageRepo(db *sqlx.DB) *ResourcePageRepository {
 	return &ResourcePageRepository{db: db}
 }
 
+func (r *ResourcePageRepository) GetAll(ctx context.Context) ([]models.ResourcePage, error) {
+	var rows []dto.ResourcePageDB
+	err := r.db.SelectContext(ctx, &rows, `
+			SELECT slug, title, content, links, updated_at
+			FROM resource_pages
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("get all resource pages: %w", err)
+	}
+
+	pages := make([]models.ResourcePage, 0, len(rows))
+	for _, row := range rows {
+		p, err := toDomain(&row)
+		if err != nil {
+			return nil, fmt.Errorf("map resource page %s: %w", row.Slug, err)
+		}
+		pages = append(pages, *p)
+	}
+	return pages, nil
+}
+
 func (r *ResourcePageRepository) GetBySlug(ctx context.Context, slug string) (*models.ResourcePage, error) {
-	return r.GetBySlugTx(ctx, r.db, slug, false)
+	var row dto.ResourcePageDB
+	err := r.db.GetContext(ctx, &row, `
+			SELECT slug, title, content, links, updated_at
+			FROM resource_pages
+			WHERE slug = $1
+	`, slug)
+	if err != nil {
+		return nil, fmt.Errorf("get resource page by slug: %w", err)
+	}
+	return toDomain(&row)
 }
 
-func (r *ResourcePageRepository) GetBySlugTx(ctx context.Context, queryable repository.Queryable, slug string, lockForUpdate bool) (*models.ResourcePage, error) {
-	var dbModel models.ResourcePageDB
-	query := "SELECT slug, title, content, links, updated_at FROM resource_pages WHERE slug = $1"
-	if lockForUpdate {
-		query += " FOR UPDATE"
-	}
-	query += ";"
-
-	err := queryable.GetContext(ctx, &dbModel, query, slug)
-	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
-			return nil, models.ErrResourcePageNotFound
+func (r *ResourcePageRepository) Update(ctx context.Context, slug string, page models.ResourcePage) (*models.ResourcePage, error) {
+	for i := range page.Links {
+		if page.Links[i].ID == "" {
+			page.Links[i].ID = uuid.New().String()
 		}
-		return nil, err
 	}
 
-	domainModel, err := toDomainDB(&dbModel)
+	linksJSON, err := json.Marshal(page.Links)
 	if err != nil {
-		return nil, fmt.Errorf("error converting DB model to domain model: %w", err)
+		return nil, fmt.Errorf("marshal links: %w", err)
 	}
 
-	return domainModel, nil
+	var row dto.ResourcePageDB
+	err = r.db.GetContext(ctx, &row, `
+			UPDATE resource_pages
+			SET title = $1, content = $2, links = $3, updated_at = NOW()
+			WHERE slug = $4
+			RETURNING slug, title, content, links, updated_at
+	`, page.Title, page.Content, linksJSON, slug)
+	if err != nil {
+		return nil, fmt.Errorf("update resource page: %w", err)
+	}
+
+	result, err := toDomain(&row)
+	return result, err
 }
 
-func (r *ResourcePageRepository) UpdatePageContentAndLinksTx(ctx context.Context, tx *sqlx.Tx, slug string, title string, content string, links []models.ResourcePageLink) error {
-	domainModel := &models.ResourcePage{
-		Slug:    slug,
-		Title:   title,
-		Content: content,
-		Links:   links,
-	}
-	dbModel, err := toRepoDB(domainModel)
+func (r *ResourcePageRepository) Clear(ctx context.Context, slug string) (*models.ResourcePage, error) {
+	var row dto.ResourcePageDB
+	err := r.db.GetContext(ctx, &row, `
+			UPDATE resource_pages
+			SET content = '', links = '[]'::jsonb, updated_at = NOW()
+			WHERE slug = $1
+			RETURNING slug, title, content, links, updated_at
+	`, slug)
 	if err != nil {
-		return fmt.Errorf("error converting domain model to DB model for update: %w", err)
+		return nil, fmt.Errorf("clear resource page: %w", err)
 	}
+	return toDomain(&row)
+}
 
-	query := `
-		UPDATE resource_pages
-		SET
-			title = $2,
-			content = $3,
-			links = $4,
+func (r *ResourcePageRepository) DeleteLink(ctx context.Context, slug string, id string) (*models.ResourcePage, error) {
+	var row dto.ResourcePageDB
+	err := r.db.GetContext(ctx, &row, `
+			UPDATE resource_pages
+			SET links = COALESCE(
+				(
+					SELECT jsonb_agg(el)
+					FROM jsonb_array_elements(links) el
+					WHERE el->>'id' != $1
+				),
+				'[]'::jsonb
+			),
 			updated_at = NOW()
-		WHERE slug = $1;
-	`
-
-	result, err := tx.ExecContext(ctx, query, dbModel.Slug, dbModel.Title, dbModel.Content, dbModel.LinksJSON)
+			WHERE slug = $2
+			RETURNING slug, title, content, links, updated_at
+	`, id, slug)
 	if err != nil {
-		return fmt.Errorf("error updating resource page in transaction: %w", err)
+		return nil, fmt.Errorf("delete link: %w", err)
 	}
-
-	rowsAffected, err := result.RowsAffected()
-	if err != nil {
-		return fmt.Errorf("error updating resource page in transaction: %w", err)
-	}
-	if rowsAffected == 0 {
-		return models.ErrResourcePageNotFound
-	}
-
-	return nil
+	return toDomain(&row)
 }
 
-func (r *ResourcePageRepository) GetAllSummaries(ctx context.Context) ([]*models.ResourcePage, error) {
-	query := "SELECT slug, title, updated_at FROM resource_pages ORDER BY updated_at DESC;"
-	var dbModels []struct {
-		Slug      string    `db:"slug"`
-		Title     string    `db:"title"`
-		UpdatedAt time.Time `db:"updated_at"`
-	}
-
-	err := r.db.SelectContext(ctx, &dbModels, query)
-	if err != nil {
-		return nil, fmt.Errorf("error querying resource page summaries: %w", err)
-	}
-
-	domainModels := make([]*models.ResourcePage, len(dbModels))
-	for i, dbMod := range dbModels {
-		domainModels[i] = &models.ResourcePage{
-			Slug:      dbMod.Slug,
-			Title:     dbMod.Title,
-			UpdatedAt: dbMod.UpdatedAt.Format(time.RFC3339),
-		}
-	}
-
-	return domainModels, nil
-}
-
-func (r *ResourcePageRepository) BeginTx(ctx context.Context) (*sqlx.Tx, error) {
-	return r.db.BeginTxx(ctx, nil)
-}
-
-func toDomainDB(dbModel *models.ResourcePageDB) (*models.ResourcePage, error) {
-	if dbModel == nil {
-		return nil, nil
-	}
-
+func toDomain(row *dto.ResourcePageDB) (*models.ResourcePage, error) {
 	var links []models.ResourcePageLink
-	if len(dbModel.LinksJSON) > 0 {
-		if err := json.Unmarshal(dbModel.LinksJSON, &links); err != nil {
-			return nil, err
+	if len(row.Links) > 0 {
+		if err := json.Unmarshal(row.Links, &links); err != nil {
+			return nil, fmt.Errorf("unmarshal links: %w", err)
 		}
 	}
-
-	var content string
-	if dbModel.Content != nil {
-		content = *dbModel.Content
+	if links == nil {
+		links = []models.ResourcePageLink{}
 	}
 
 	return &models.ResourcePage{
-		Slug:      dbModel.Slug,
-		Title:     dbModel.Title,
-		Content:   content,
+		Slug:      row.Slug,
+		Title:     row.Title,
+		Content:   row.Content,
 		Links:     links,
-		LinksJSON: dbModel.LinksJSON,
-		UpdatedAt: dbModel.UpdatedAt.Format(time.RFC3339),
-	}, nil
-}
-
-func toRepoDB(domainModel *models.ResourcePage) (*models.ResourcePageDB, error) {
-	if domainModel == nil {
-		return nil, nil
-	}
-
-	linksJSON, err := json.Marshal(domainModel.Links)
-	if err != nil {
-		return nil, err
-	}
-
-	var contentPtr *string
-	if domainModel.Content != "" {
-		contentPtr = &domainModel.Content
-	}
-
-	return &models.ResourcePageDB{
-		Slug:      domainModel.Slug,
-		Title:     domainModel.Title,
-		Content:   contentPtr,
-		LinksJSON: linksJSON,
+		UpdatedAt: row.UpdatedAt,
 	}, nil
 }

--- a/internal/repository/postgres/resource_page_test.go
+++ b/internal/repository/postgres/resource_page_test.go
@@ -1,0 +1,139 @@
+package postgres
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/yandex-development-1-team/go/internal/models"
+)
+
+func TestResourcePageRepo_GetAll(t *testing.T) {
+	ctx := context.Background()
+
+	pages, err := resourcePageRepo.GetAll(ctx)
+	require.NoError(t, err)
+	assert.Len(t, pages, 4)
+}
+
+func TestResourcePageRepo_GetBySlug(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("existing slug", func(t *testing.T) {
+		page, err := resourcePageRepo.GetBySlug(ctx, "faq")
+		require.NoError(t, err)
+		assert.Equal(t, "faq", page.Slug)
+		assert.NotEmpty(t, page.Title)
+		assert.NotNil(t, page.Links)
+	})
+}
+
+func TestResourcePageRepo_Update(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("updates content", func(t *testing.T) {
+		page := models.ResourcePage{
+			Title:   "Информация об организации",
+			Content: "Новое описание",
+			Links:   []models.ResourcePageLink{},
+		}
+
+		updated, err := resourcePageRepo.Update(ctx, "organizationInfo", page)
+		require.NoError(t, err)
+		assert.Equal(t, "Новое описание", updated.Content)
+		assert.Empty(t, updated.Links)
+	})
+
+	t.Run("generates uuid for new link", func(t *testing.T) {
+		page := models.ResourcePage{
+			Title:   "Полезные ссылки",
+			Content: "",
+			Links: []models.ResourcePageLink{
+				{Title: "Сайт", URL: "https://example.com"},
+			},
+		}
+
+		updated, err := resourcePageRepo.Update(ctx, "usefulLinks", page)
+		require.NoError(t, err)
+		assert.Len(t, updated.Links, 1)
+		assert.NotEmpty(t, updated.Links[0].ID)
+		assert.Equal(t, "Сайт", updated.Links[0].Title)
+	})
+
+	t.Run("keeps existing uuid", func(t *testing.T) {
+		existingID := "550e8400-e29b-41d4-a716-446655440000"
+		page := models.ResourcePage{
+			Title:   "Полезные ссылки",
+			Content: "",
+			Links: []models.ResourcePageLink{
+				{ID: existingID, Title: "Сайт", URL: "https://example.com"},
+			},
+		}
+
+		updated, err := resourcePageRepo.Update(ctx, "usefulLinks", page)
+		require.NoError(t, err)
+		assert.Equal(t, existingID, updated.Links[0].ID)
+	})
+}
+
+func TestResourcePageRepo_Clear(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("clears content and links", func(t *testing.T) {
+		_, err := resourcePageRepo.Update(ctx, "faq", models.ResourcePage{
+			Title:   "FAQ",
+			Content: "Какой-то контент",
+			Links:   []models.ResourcePageLink{{Title: "Ссылка", URL: "https://example.com"}},
+		})
+		require.NoError(t, err)
+
+		cleared, err := resourcePageRepo.Clear(ctx, "faq")
+		require.NoError(t, err)
+		assert.Equal(t, "faq", cleared.Slug)
+		assert.Empty(t, cleared.Content)
+		assert.Empty(t, cleared.Links)
+	})
+}
+
+func TestResourcePageRepo_DeleteLink(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("deletes link by id", func(t *testing.T) {
+		page := models.ResourcePage{
+			Title:   "Полезные ссылки",
+			Content: "",
+			Links: []models.ResourcePageLink{
+				{Title: "Первая", URL: "https://first.com"},
+				{Title: "Вторая", URL: "https://second.com"},
+			},
+		}
+		updated, err := resourcePageRepo.Update(ctx, "usefulLinks", page)
+		require.NoError(t, err)
+		require.Len(t, updated.Links, 2)
+
+		idToDelete := updated.Links[0].ID
+
+		result, err := resourcePageRepo.DeleteLink(ctx, "usefulLinks", idToDelete)
+		require.NoError(t, err)
+		assert.Len(t, result.Links, 1)
+		assert.Equal(t, updated.Links[1].ID, result.Links[0].ID)
+	})
+
+	t.Run("returns empty links when last link deleted", func(t *testing.T) {
+		page := models.ResourcePage{
+			Title:   "Полезные ссылки",
+			Content: "",
+			Links: []models.ResourcePageLink{
+				{Title: "Единственная", URL: "https://example.com"},
+			},
+		}
+		updated, err := resourcePageRepo.Update(ctx, "usefulLinks", page)
+		require.NoError(t, err)
+		require.Len(t, updated.Links, 1)
+
+		result, err := resourcePageRepo.DeleteLink(ctx, "usefulLinks", updated.Links[0].ID)
+		require.NoError(t, err)
+		assert.Empty(t, result.Links)
+	})
+}

--- a/internal/service/resourse_page.go
+++ b/internal/service/resourse_page.go
@@ -2,10 +2,7 @@ package service
 
 import (
 	"context"
-	"database/sql"
-	"errors"
 	"fmt"
-	"log"
 
 	"github.com/yandex-development-1-team/go/internal/models"
 	"github.com/yandex-development-1-team/go/internal/repository"
@@ -23,110 +20,32 @@ func (s *ResourcePageService) GetResourcePage(ctx context.Context, slug string) 
 	return s.repo.GetBySlug(ctx, slug)
 }
 
-func (s *ResourcePageService) UpdateResourcePage(ctx context.Context, slug string, newPageData *models.ResourcePage) (*models.ResourcePage, error) {
-	tx, err := s.repo.BeginTx(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("failed to begin transaction: %w", err)
-	}
-	defer func() {
-		if err := tx.Rollback(); err != nil && !errors.Is(err, sql.ErrTxDone) {
-			log.Printf("ERROR: failed to rollback transaction: %v", err)
-		}
-	}()
-
-	currentPage, err := s.repo.GetBySlugTx(ctx, tx, slug, true)
-	if err != nil {
-		return nil, err
-	}
-
-	if newPageData.Title != "" {
-		currentPage.Title = newPageData.Title
-	}
-	if newPageData.Content != "" {
-		currentPage.Content = newPageData.Content
-	}
-	if newPageData.Links != nil {
-		newLinksMap := make(map[string]models.ResourcePageLink, len(newPageData.Links))
-		for _, link := range newPageData.Links {
-			newLinksMap[link.ID] = link
-		}
-
-		updatedLinks := make([]models.ResourcePageLink, 0, len(newLinksMap)+len(newPageData.Links))
-
-		for _, link := range currentPage.Links {
-			if v, exists := newLinksMap[link.ID]; exists {
-				updatedLinks = append(updatedLinks, v)
-				delete(newLinksMap, link.ID)
-			} else {
-				updatedLinks = append(updatedLinks, link)
-			}
-		}
-
-		for _, link := range newPageData.Links {
-			if _, exists := newLinksMap[link.ID]; exists {
-				updatedLinks = append(updatedLinks, link)
-			}
-		}
-
-		currentPage.Links = updatedLinks
-	}
-
-	err = s.repo.UpdatePageContentAndLinksTx(ctx, tx, currentPage.Slug, currentPage.Title, currentPage.Content, currentPage.Links)
-	if err != nil {
-		return nil, fmt.Errorf("failed to update resource page in transaction: %w", err)
-	}
-
-	if err = tx.Commit(); err != nil {
-		return nil, fmt.Errorf("failed to commit transaction: %w", err)
-	}
-
-	return currentPage, nil
+func (s *ResourcePageService) GetAllResourcePages(ctx context.Context) ([]models.ResourcePage, error) {
+	return s.repo.GetAll(ctx)
 }
 
-func (s *ResourcePageService) DeleteLink(ctx context.Context, slug string, linkID string) error {
-	tx, err := s.repo.BeginTx(ctx)
+func (s *ResourcePageService) UpdateResourcePage(ctx context.Context, slug string, page models.ResourcePage) (*models.ResourcePage, error) {
+	updated, err := s.repo.Update(ctx, slug, page)
 	if err != nil {
-		return fmt.Errorf("failed to begin transaction: %w", err)
+		return nil, fmt.Errorf("update resource page: %w", err)
 	}
 
-	defer func() {
-		if err := tx.Rollback(); err != nil && !errors.Is(err, sql.ErrTxDone) {
-			log.Printf("ERROR: failed to rollback transaction: %v", err)
-		}
-	}()
-
-	currentPage, err := s.repo.GetBySlugTx(ctx, tx, slug, true)
-	if err != nil {
-		return err
-	}
-
-	found := false
-	newLinks := make([]models.ResourcePageLink, 0, len(currentPage.Links))
-	for _, link := range currentPage.Links {
-		if link.ID != linkID {
-			newLinks = append(newLinks, link)
-		} else {
-			found = true
-		}
-	}
-
-	if !found {
-		return fmt.Errorf("link with id '%s' not found in page '%s'", linkID, slug)
-	}
-
-	currentPage.Links = newLinks
-	err = s.repo.UpdatePageContentAndLinksTx(ctx, tx, currentPage.Slug, currentPage.Title, currentPage.Content, currentPage.Links)
-	if err != nil {
-		return fmt.Errorf("failed to update page after deleting link: %w", err)
-	}
-
-	if err = tx.Commit(); err != nil {
-		return fmt.Errorf("failed to commit transaction: %w", err)
-	}
-
-	return nil
+	return updated, nil
 }
 
-func (s *ResourcePageService) GetAllSummaries(ctx context.Context) ([]*models.ResourcePage, error) {
-	return s.repo.GetAllSummaries(ctx)
+func (s *ResourcePageService) ClearResourcePage(ctx context.Context, slug string) (*models.ResourcePage, error) {
+	cleared, err := s.repo.Clear(ctx, slug)
+	if err != nil {
+		return nil, fmt.Errorf("clear resource page: %w", err)
+	}
+
+	return cleared, nil
+}
+
+func (s *ResourcePageService) DeleteResourcePageLink(ctx context.Context, slug string, id string) (*models.ResourcePage, error) {
+	page, err := s.repo.DeleteLink(ctx, slug, id)
+	if err != nil {
+		return nil, fmt.Errorf("delete resource page link: %w", err)
+	}
+	return page, nil
 }

--- a/migrations/20260307182548_create_resource_pages.sql
+++ b/migrations/20260307182548_create_resource_pages.sql
@@ -11,10 +11,10 @@ CREATE TABLE IF NOT EXISTS resource_pages (
 CREATE INDEX IF NOT EXISTS idx_resource_pages_updated_at ON resource_pages (updated_at);
 
 INSERT INTO resource_pages (slug, title, content) VALUES 
-('organizationInfo', 'Организационная информация', 'Компания полного цикла в организации мероприятий — от корпоративов и конференций до партнёрских программ и спецпроектов. Работает с крупными клиентами, имеет собственную команду менеджеров и отлаженные процессы под любой масштаб события.'),
-('usefulLinks', 'Полезные ссылки', ''),
+('org-info', 'Организационная информация', 'Компания полного цикла в организации мероприятий — от корпоративов и конференций до партнёрских программ и спецпроектов. Работает с крупными клиентами, имеет собственную команду менеджеров и отлаженные процессы под любой масштаб события.'),
+('useful-links', 'Полезные ссылки', ''),
 ('faq', 'FAQ', 'https://disk.yandex.ru/i/nWbTdaWA9Xcgdg'),
-('eventSchedule', 'Афиша Pertner Relations', 'https://afisha.yandex.ru');
+('event-schedule', 'Афиша Pertner Relations', 'https://afisha.yandex.ru');
 
 
 -- +goose Down

--- a/migrations/20260307182548_create_resource_pages.sql
+++ b/migrations/20260307182548_create_resource_pages.sql
@@ -2,7 +2,7 @@
 CREATE TABLE IF NOT EXISTS resource_pages (
     slug VARCHAR(255) PRIMARY KEY,
     title TEXT NOT NULL,
-    content TEXT,
+    content TEXT NOT NULL DEFAULT '',
     links JSONB DEFAULT '[]'::jsonb,
     created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
@@ -11,10 +11,10 @@ CREATE TABLE IF NOT EXISTS resource_pages (
 CREATE INDEX IF NOT EXISTS idx_resource_pages_updated_at ON resource_pages (updated_at);
 
 INSERT INTO resource_pages (slug, title, content) VALUES 
-('organizationInfo', 'Организационная информация', 'Текст о нас'),
+('organizationInfo', 'Организационная информация', 'Компания полного цикла в организации мероприятий — от корпоративов и конференций до партнёрских программ и спецпроектов. Работает с крупными клиентами, имеет собственную команду менеджеров и отлаженные процессы под любой масштаб события.'),
 ('usefulLinks', 'Полезные ссылки', ''),
-('faq', 'FAQ', ''),
-('eventSchedule', 'Афиша Pertner Relations', '');
+('faq', 'FAQ', 'https://disk.yandex.ru/i/nWbTdaWA9Xcgdg'),
+('eventSchedule', 'Афиша Pertner Relations', 'https://afisha.yandex.ru');
 
 
 -- +goose Down


### PR DESCRIPTION
Изменена бизнес-логика
1. При PUT получаем массив ссылок, массив перезаписывается в БД. 
2. DELETE  /api/v1/resources/{slug}/{id} - удаляет 1 ссылку из JSONB в бд.
3. DELETE /resources/{slug} - добавлена ручка для удаления content + links. Очищает указанные поля в бд. После согласования "удалить" в разделе "О нас" возможно удаление ручки.
4. Спецификация соответствует текущим request/response
5. Все ручки возвращают обновленные сущности указанного slug.