### PR TITLE
fix: add create, update and block user endpoints

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -68,6 +68,7 @@ jobs:
           CI_CADDY_LETSENCRYPT_EMAIL: ${{ vars.CADDY_LETSENCRYPT_EMAIL }}
           CI_JWT_SECRET: ${{ secrets.JWT_SECRET }}
           CI_DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
+          CI_YANDEX_FORMS_WEBHOOK_TOKEN: ${{ secrets.YANDEX_FORMS_WEBHOOK_TOKEN }}
         run: |
           pip3 install dump-env
           dump-env \

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ bot:
 
 1. Скопируйте пример env-файла и укажите токен:
    ```bash
-   cp .env.example .env
+   cp .env .env
    # отредактируйте .env: BOT_TOKEN=ваш_токен_от_BotFather
    ```
 2. Запуск:

--- a/cmd/bot/main.go
+++ b/cmd/bot/main.go
@@ -117,6 +117,7 @@ func run() error {
 	analyticsService := apiService.NewAnalyticsService(analyticsRepo)
 	resourcePageService := service.NewResourcePageService(resourcePageRepo)
 	userService := apiService.NewUserService(staffRepo)
+	usersAdminService := apiService.NewUsersAdminService(staffRepo, refreshTokenRepoRepo)
 
 	metricsMux := http.NewServeMux()
 	metricsMux.Handle("/metrics", metrics.NewHandler())
@@ -144,6 +145,7 @@ func run() error {
 		UserSvc:           userService,
 		FileService:       fileService,
 		ApplicationRepo:   applicationRepo,
+		UsersAdmin:        usersAdminService,
 	}, apiAuthService)
 
 	if cfg.FileGC.Enabled {

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -721,6 +721,206 @@
         }
       }
     },
+    "/api/v1/bookings": {
+      "get": {
+        "summary": "Список заявок",
+        "tags": [
+          "bookings"
+        ],
+        "parameters": [
+          {
+            "name": "status",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "pending",
+                "confirmed",
+                "cancelled"
+              ]
+            }
+          },
+          {
+            "name": "manager_id",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int64",
+              "minimum": 1
+            }
+          },
+          {
+            "name": "customer_name",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "default": 20,
+              "minimum": 1,
+              "maximum": 100
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "default": 0,
+              "minimum": 0
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Список заявок",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "items": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/BookingListItem"
+                      }
+                    },
+                    "pagination": {
+                      "$ref": "#/components/schemas/Pagination"
+                    }
+                  },
+                  "required": [
+                    "items",
+                    "pagination"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/UnauthorizedError"
+          }
+        }
+      }
+    },
+    "/api/v1/bookings/{id}": {
+      "get": {
+        "summary": "Детали бронирования",
+        "tags": [
+          "bookings"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/IdPathParam"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Бронирование",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Booking"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/UnauthorizedError"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFoundError"
+          }
+        }
+      },
+      "delete": {
+        "summary": "Удалить бронирование",
+        "tags": [
+          "bookings"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/IdPathParam"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Бронирование удалено"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFoundError"
+          },
+          "401": {
+            "$ref": "#/components/responses/UnauthorizedError"
+          }
+        }
+      }
+    },
+    "/api/v1/bookings/{id}/status": {
+      "put": {
+        "summary": "Сменить статус бронирования",
+        "tags": [
+          "bookings"
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/IdPathParam"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "status": {
+                    "type": "string",
+                    "enum": [
+                      "pending",
+                      "confirmed",
+                      "cancelled"
+                    ]
+                  }
+                },
+                "required": [
+                  "status"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Статус обновлён",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Booking"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/UnauthorizedError"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFoundError"
+          }
+        }
+      }
+    },
     "/api/v1/events": {
       "get": {
         "summary": "Список событий/слотов",
@@ -1075,20 +1275,9 @@
             "schema": {
               "type": "string",
               "enum": [
-                "queue",
-                "in_progress",
-                "done"
-              ]
-            }
-          },
-          {
-            "name": "type",
-            "in": "query",
-            "schema": {
-              "type": "string",
-              "enum": [
-                "box",
-                "special_project"
+                "pending",
+                "confirmed",
+                "cancelled"
               ]
             }
           },
@@ -1154,39 +1343,11 @@
               }
             }
           },
-          "401": {
-            "$ref": "#/components/responses/UnauthorizedError"
-          }
-        }
-      },
-      "post": {
-        "summary": "Создать заявку (из бота или вручную)",
-        "tags": [
-          "applications"
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ApplicationCreateRequest"
-              }
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": "Заявка создана",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Application"
-                }
-              }
-            }
-          },
           "400": {
             "$ref": "#/components/responses/ValidationError"
+          },
+          "401": {
+            "$ref": "#/components/responses/UnauthorizedError"
           }
         }
       }
@@ -1221,48 +1382,6 @@
           }
         }
       },
-      "put": {
-        "summary": "Обновить заявку",
-        "tags": [
-          "applications"
-        ],
-        "parameters": [
-          {
-            "$ref": "#/components/parameters/IdPathParam"
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ApplicationUpdateRequest"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Заявка обновлена",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Application"
-                }
-              }
-            }
-          },
-          "400": {
-            "$ref": "#/components/responses/ValidationError"
-          },
-          "401": {
-            "$ref": "#/components/responses/UnauthorizedError"
-          },
-          "404": {
-            "$ref": "#/components/responses/NotFoundError"
-          }
-        }
-      },
       "delete": {
         "summary": "Удалить заявку",
         "tags": [
@@ -1274,39 +1393,23 @@
           }
         ],
         "responses": {
-          "200": {
-            "description": "Заявка удалена",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "message": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "message"
-                  ]
-                }
-              }
-            }
-          },
-          "401": {
-            "$ref": "#/components/responses/UnauthorizedError"
+          "204": {
+            "description": "Заявка удалена"
           },
           "404": {
             "$ref": "#/components/responses/NotFoundError"
+          },
+          "401": {
+            "$ref": "#/components/responses/UnauthorizedError"
           }
         }
       }
     },
-    "/api/v1/applications/{id}/create-box": {
-      "post": {
-        "summary": "Создать коробку из заявки",
+    "/api/v1/applications/{id}/status": {
+      "put": {
+        "summary": "Сменить статус заявки на специальное преложение",
         "tags": [
-          "applications",
-          "boxes"
+          "applications"
         ],
         "parameters": [
           {
@@ -1318,18 +1421,31 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/CreateBoxFromApplicationRequest"
+                "type": "object",
+                "properties": {
+                  "status": {
+                    "type": "string",
+                    "enum": [
+                      "pending",
+                      "confirmed",
+                      "cancelled"
+                    ]
+                  }
+                },
+                "required": [
+                  "status"
+                ]
               }
             }
           }
         },
         "responses": {
           "200": {
-            "description": "Коробка создана и связана с заявкой",
+            "description": "Статус обновлён",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/CreateBoxFromApplicationResponse"
+                  "$ref": "#/components/schemas/Application"
                 }
               }
             }
@@ -2542,6 +2658,133 @@
           }
         }
       },
+      "Booking": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "user_id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "service_id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "service_name": {
+            "type": "string"
+          },
+          "booking_date": {
+            "type": "string",
+            "format": "date"
+          },
+          "booking_time": {
+            "type": "string",
+            "example": "15:04"
+          },
+          "guest_name": {
+            "type": "string"
+          },
+          "guest_organization": {
+            "type": "string"
+          },
+          "guest_contact": {
+            "type": "string"
+          },
+          "guest_position": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "pending",
+              "confirmed",
+              "cancelled"
+            ]
+          },
+          "manager_id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "manager_name": {
+            "type": "string"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "id",
+          "user_id",
+          "service_id",
+          "service_name",
+          "booking_date",
+          "booking_time",
+          "guest_name",
+          "guest_organization",
+          "guest_contact",
+          "guest_position",
+          "status",
+          "manager_id",
+          "manager_name",
+          "created_at",
+          "updated_at"
+        ]
+      },
+      "BookingListItem": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "pending",
+              "confirmed",
+              "cancelled"
+            ]
+          },
+          "guest_name": {
+            "type": "string"
+          },
+          "guest_contact": {
+            "type": "string"
+          },
+          "service_name": {
+            "type": "string"
+          },
+          "manager_id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "manager_name": {
+            "type": "string"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "id",
+          "status",
+          "guest_name",
+          "guest_contact",
+          "service_name",
+          "manager_id",
+          "manager_name",
+          "created_at"
+        ]
+      },
       "Event": {
         "type": "object",
         "properties": {
@@ -2727,56 +2970,32 @@
             "type": "integer",
             "format": "int64"
           },
-          "type": {
+          "status": {
             "type": "string",
             "enum": [
-              "box",
-              "special_project"
+              "pending",
+              "confirmed",
+              "cancelled"
             ]
           },
-          "source": {
-            "type": "string",
-            "enum": [
-              "telegram_bot",
-              "manual"
-            ]
+          "manager_id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "manager_name": {
+            "type": "string"
+          },
+          "form_answer_id": {
+            "type": "string"
           },
           "customer_name": {
             "type": "string"
           },
-          "project_name": {
-            "type": "string",
-            "nullable": true
-          },
           "contact_info": {
             "type": "string"
           },
-          "status": {
-            "type": "string",
-            "enum": [
-              "queue",
-              "in_progress",
-              "done"
-            ]
-          },
-          "box_id": {
-            "type": "integer",
-            "format": "int64",
-            "nullable": true
-          },
-          "special_project_id": {
-            "type": "integer",
-            "format": "int64",
-            "nullable": true
-          },
-          "manager_id": {
-            "type": "integer",
-            "format": "int64",
-            "nullable": true
-          },
-          "manager_name": {
-            "type": "string",
-            "nullable": true
+          "description": {
+            "type": "string"
           },
           "created_at": {
             "type": "string",
@@ -2789,13 +3008,14 @@
         },
         "required": [
           "id",
-          "type",
-          "source",
           "customer_name",
           "contact_info",
           "status",
+          "manager_id",
+          "manager_name",
           "created_at",
-          "updated_at"
+          "updated_at",
+          "form_answer_id"
         ]
       },
       "ApplicationCreateRequest": {
@@ -2851,75 +3071,40 @@
             "type": "integer",
             "format": "int64"
           },
-          "type": {
+          "status": {
             "type": "string",
             "enum": [
-              "box",
-              "special_project"
+              "pending",
+              "confirmed",
+              "cancelled"
             ]
           },
-          "source": {
-            "type": "string",
-            "enum": [
-              "telegram_bot",
-              "manual"
-            ]
+          "manager_id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "manager_name": {
+            "type": "string"
           },
           "customer_name": {
             "type": "string"
           },
-          "project_name": {
-            "type": "string",
-            "nullable": true
-          },
           "contact_info": {
             "type": "string"
           },
-          "status": {
-            "type": "string",
-            "enum": [
-              "queue",
-              "in_progress",
-              "done"
-            ]
-          },
-          "box_id": {
-            "type": "integer",
-            "format": "int64",
-            "nullable": true
-          },
-          "special_project_id": {
-            "type": "integer",
-            "format": "int64",
-            "nullable": true
-          },
-          "manager_id": {
-            "type": "integer",
-            "format": "int64",
-            "nullable": true
-          },
-          "manager_name": {
-            "type": "string",
-            "nullable": true
-          },
           "created_at": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "updated_at": {
             "type": "string",
             "format": "date-time"
           }
         },
         "required": [
           "id",
-          "type",
-          "source",
           "customer_name",
           "contact_info",
           "status",
           "created_at",
-          "updated_at"
+          "manager_id",
+          "manager_name"
         ]
       },
       "ApplicationUpdateRequest": {
@@ -3135,18 +3320,14 @@
           "position": {
             "type": "string"
           },
-          "manager_id": {
-            "type": "integer",
-            "format": "int64"
+          "supervisor": {
+            "type": "string"
+          },
+          "address": {
+            "type": "string"
           },
           "invite_token": {
             "type": "string"
-          },
-          "permissions": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
           },
           "created_at": {
             "type": "string",
@@ -3186,10 +3367,13 @@
       "UserCreateRequest": {
         "type": "object",
         "properties": {
-          "telegram_nick": {
+          "first_name": {
             "type": "string"
           },
-          "name": {
+          "last_name": {
+            "type": "string"
+          },
+          "second_name": {
             "type": "string"
           },
           "email": {
@@ -3201,46 +3385,63 @@
           "status": {
             "type": "string"
           },
-          "permissions": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
+          "phone": {
+            "type": "string"
+          },
+          "department": {
+            "type": "string"
+          },
+          "position": {
+            "type": "string"
+          },
+          "supervisor": {
+            "type": "string"
+          },
+          "address": {
+            "type": "string"
           }
         },
-        "required": [
-          "name",
-          "email",
-          "role"
-        ]
+        "required": ["first_name", "last_name", "email", "role"]
       },
       "UserUpdateRequest": {
         "type": "object",
         "properties": {
-          "telegram_nick": {
+          "first_name": {
             "type": "string"
           },
-          "name": {
+          "last_name": {
+            "type": "string"
+          },
+          "second_name": {
             "type": "string"
           },
           "email": {
-            "type": "string"
+            "type": "string", "format": "email"
           },
           "role": {
-            "type": "string"
+            "type": "string", "enum": ["admin", "manager_1", "manager_2", "manager_3", "user"]
           },
           "status": {
+            "type": "string", "enum": ["active", "blocked", "invited"]
+          },
+          "phone_number": {
             "type": "string"
           },
-          "permissions": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
+          "department": {
+            "type": "string"
+          },
+          "position": {
+            "type": "string"
+          },
+          "supervisor": {
+            "type": "string"
+          },
+          "address": {
+            "type": "string"
           }
         }
       },
-      "UserWithDetails": {
+      "UserWithDetails":  {
         "allOf": [
           {
             "$ref": "#/components/schemas/User"

--- a/internal/api/handlers/applications.go
+++ b/internal/api/handlers/applications.go
@@ -65,17 +65,10 @@ func (h *ApplicationHandler) List(c *gin.Context) {
 		return
 	}
 
-	managerID, ok := parseOptionalPositiveInt64(c.Query("manager_id"))
-	if !ok {
-		apierrors.WriteErrorMessagesGin(c, http.StatusBadRequest, []string{"Неверные параметры запроса"})
-		return
-	}
-
 	filter := models.ApplicationFilter{
 		CustomerName: req.CustomerName,
 		Limit:        limit,
 		Offset:       offset,
-		ManagerID:    managerID,
 	}
 
 	if req.Status != nil {

--- a/internal/api/handlers/applications_test.go
+++ b/internal/api/handlers/applications_test.go
@@ -123,7 +123,6 @@ func performRawRequest(
 func sampleApplication() *models.Application {
 	now := time.Date(2026, 4, 8, 12, 0, 0, 0, time.UTC)
 
-	managerID := int64(7)
 	boxID := int64(11)
 	managerName := "Анна Петрова"
 	projectName := "Проект А"
@@ -137,7 +136,6 @@ func sampleApplication() *models.Application {
 		ContactInfo:  "ivan@example.com",
 		ProjectName:  &projectName,
 		BoxID:        &boxID,
-		ManagerID:    &managerID,
 		ManagerName:  &managerName,
 		CreatedAt:    now,
 		UpdatedAt:    now,
@@ -484,34 +482,6 @@ func TestApplicationHandler_List(t *testing.T) {
 		require.Equal(t, http.StatusOK, w.Code)
 		require.NotNil(t, captured.Status)
 		assert.Equal(t, models.ApplicationStatusQueue, *captured.Status)
-	})
-
-	t.Run("filter by manager_id", func(t *testing.T) {
-		var captured models.ApplicationFilter
-
-		repo := &mockApplicationRepo{
-			listFn: func(_ context.Context, filter models.ApplicationFilter) ([]models.Application, int, error) {
-				captured = filter
-				return []models.Application{}, 0, nil
-			},
-		}
-		router := newApplicationTestRouter(repo)
-
-		w := performJSONRequest(t, router, http.MethodGet, "/applications?manager_id=42", nil)
-
-		require.Equal(t, http.StatusOK, w.Code)
-		require.NotNil(t, captured.ManagerID)
-		assert.Equal(t, int64(42), *captured.ManagerID)
-	})
-
-	t.Run("invalid manager_id", func(t *testing.T) {
-		repo := &mockApplicationRepo{}
-		router := newApplicationTestRouter(repo)
-
-		w := performJSONRequest(t, router, http.MethodGet, "/applications?manager_id=abc", nil)
-
-		require.Equal(t, http.StatusBadRequest, w.Code)
-		assertAPIErrorsBodyHasExactMessage(t, w.Body.Bytes(), "Неверные параметры запроса")
 	})
 
 	t.Run("response contains manager_name", func(t *testing.T) {

--- a/internal/api/handlers/auth.go
+++ b/internal/api/handlers/auth.go
@@ -2,8 +2,8 @@ package handlers
 
 import (
 	"context"
-	"net/http"
 	"log"
+	"net/http"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -160,9 +160,7 @@ func toUserResponse(user *models.UserAPI) dto.UserResponse {
 		Status:       user.Status,
 		Department:   user.Department,
 		Position:     user.Position,
-		ManagerID:    user.ManagerID,
 		InviteToken:  user.InviteToken,
-		Permissions:  user.Permissions,
 		CreatedAt:    user.CreatedAt,
 		UpdatedAt:    user.UpdatedAt,
 	}

--- a/internal/api/handlers/auth.go
+++ b/internal/api/handlers/auth.go
@@ -160,6 +160,8 @@ func toUserResponse(user *models.UserAPI) dto.UserResponse {
 		Status:       user.Status,
 		Department:   user.Department,
 		Position:     user.Position,
+		Supervisor:   user.Supervisor,
+		Address:      user.Address,
 		InviteToken:  user.InviteToken,
 		CreatedAt:    user.CreatedAt,
 		UpdatedAt:    user.UpdatedAt,

--- a/internal/api/handlers/users.go
+++ b/internal/api/handlers/users.go
@@ -76,6 +76,7 @@ type UserHandler struct {
 }
 
 func NewUserHandler(svc *apiService.UserService) *UserHandler {
+
 	return &UserHandler{svc: svc}
 }
 
@@ -126,6 +127,5 @@ func (h *UserHandler) GetByID(c *gin.Context) {
 		apierrors.WriteErrorGin(c, err)
 		return
 	}
-
 	c.JSON(http.StatusOK, user)
 }

--- a/internal/api/handlers/users.go
+++ b/internal/api/handlers/users.go
@@ -12,6 +12,65 @@ import (
 	apiService "github.com/yandex-development-1-team/go/internal/service/api"
 )
 
+type UsersHandler struct {
+	svc *apiService.UsersAdminService
+}
+
+func NewUsersHandler(svc *apiService.UsersAdminService) *UsersHandler {
+	return &UsersHandler{svc: svc}
+}
+
+func (h *UsersHandler) Create(c *gin.Context) {
+	var req dto.UserCreateRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		apierrors.WriteErrorMessagesGin(c, http.StatusBadRequest, []string{"Некорректные данные"})
+		return
+	}
+	user, err := h.svc.Create(c.Request.Context(), req)
+	if err != nil {
+		apierrors.WriteErrorGin(c, err)
+		return
+	}
+	c.JSON(http.StatusCreated, toUserResponse(user))
+}
+
+func (h *UsersHandler) Update(c *gin.Context) {
+	id, err := strconv.ParseInt(c.Param("id"), 10, 64)
+	if err != nil || id <= 0 {
+		apierrors.WriteErrorMessagesGin(c, http.StatusBadRequest, []string{"Некорректный id"})
+		return
+	}
+	var req dto.UserUpdateRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		apierrors.WriteErrorMessagesGin(c, http.StatusBadRequest, []string{"Некорректные данные"})
+		return
+	}
+	user, err := h.svc.Update(c.Request.Context(), id, req)
+	if err != nil {
+		apierrors.WriteErrorGin(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, toUserResponse(user))
+}
+
+func (h *UsersHandler) Block(c *gin.Context) {
+	id, err := strconv.ParseInt(c.Param("id"), 10, 64)
+	if err != nil || id <= 0 {
+		apierrors.WriteErrorMessagesGin(c, http.StatusBadRequest, []string{"Некорректный id"})
+		return
+	}
+	user, err := h.svc.Block(c.Request.Context(), id)
+	if err != nil {
+		apierrors.WriteErrorGin(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, dto.BlockResponse{
+		ID:        user.ID,
+		Status:    "blocked",
+		UpdatedAt: user.UpdatedAt,
+	})
+}
+
 type UserHandler struct {
 	svc *apiService.UserService
 }

--- a/internal/api/handlers/users_test.go
+++ b/internal/api/handlers/users_test.go
@@ -1,0 +1,418 @@
+//go:build integration
+
+package handlers
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/bcrypt"
+
+	pgrepo "github.com/yandex-development-1-team/go/internal/repository/postgres"
+	svcapi "github.com/yandex-development-1-team/go/internal/service/api"
+)
+
+func generateAdminToken(t *testing.T) string {
+	t.Helper()
+	claims := svcapi.AccessClaims{
+		UserID: 1,
+		Role:   "admin",
+		RegisteredClaims: jwt.RegisteredClaims{
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour)),
+		},
+	}
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	signed, err := token.SignedString([]byte("test-secret"))
+	require.NoError(t, err)
+	return signed
+}
+
+func setupUsersAdminServer(t *testing.T) *httptest.Server {
+	t.Helper()
+
+	staffRepo := pgrepo.NewStaffRepo(db)
+	refreshRepo := pgrepo.NewRefreshTokenRepo(db)
+	svc := svcapi.NewUsersAdminService(staffRepo, refreshRepo)
+	handler := NewUsersHandler(svc)
+
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+
+	router.Use(func(c *gin.Context) {
+		authHeader := c.GetHeader("Authorization")
+		if authHeader == "" {
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"errors": []string{"unauthorized"}})
+			return
+		}
+		tokenStr := authHeader[len("Bearer "):]
+		claims := &svcapi.AccessClaims{}
+		_, err := jwt.ParseWithClaims(tokenStr, claims, func(token *jwt.Token) (interface{}, error) {
+			return []byte("test-secret"), nil
+		})
+		if err != nil {
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"errors": []string{"unauthorized"}})
+			return
+		}
+		c.Set("user_id", claims.UserID)
+		c.Set("role", claims.Role)
+		c.Next()
+	})
+
+	users := router.Group("/users")
+	users.Use(func(c *gin.Context) {
+		role, _ := c.Get("role")
+		if role != "admin" {
+			c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"errors": []string{"forbidden"}})
+			return
+		}
+		c.Next()
+	})
+	{
+		users.POST("", handler.Create)
+		users.PUT("/:id", handler.Update)
+		users.PUT("/:id/block", handler.Block)
+	}
+
+	server := httptest.NewServer(router)
+	t.Cleanup(server.Close)
+	return server
+}
+
+func authHeader(token string) string {
+	return "Bearer " + token
+}
+
+func ptr(s string) *string { return &s }
+
+func TestUsersAdmin_Create_Success(t *testing.T) {
+	_, _ = db.Exec(`TRUNCATE TABLE staff CASCADE`)
+	server := setupUsersAdminServer(t)
+	token := generateAdminToken(t)
+
+	body := map[string]interface{}{
+		"first_name": "Иван",
+		"last_name":  "Иванов",
+		"email":      "ivan@example.com",
+		"role":       "manager_1",
+	}
+	b, _ := json.Marshal(body)
+
+	resp, err := doRequest(server.URL+"/users", http.MethodPost, b, authHeader(token))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusCreated, resp.StatusCode)
+
+	var result map[string]any
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&result))
+	assert.Equal(t, "ivan@example.com", result["email"])
+	assert.Equal(t, "manager_1", result["role"])
+	assert.Equal(t, "invited", result["status"])
+}
+
+func TestUsersAdmin_Create_AllFields(t *testing.T) {
+	_, _ = db.Exec(`TRUNCATE TABLE staff CASCADE`)
+	server := setupUsersAdminServer(t)
+	token := generateAdminToken(t)
+
+	body := map[string]interface{}{
+		"first_name":  "Мария",
+		"last_name":   "Петрова",
+		"second_name": "Сергеевна",
+		"email":       "maria@example.com",
+		"role":        "manager_2",
+		"phone":       "+79991234567",
+		"department":  "Маркетинг",
+		"position":    "Менеджер",
+		"supervisor":  "Иван Иванов",
+		"address":     "Москва",
+	}
+	b, _ := json.Marshal(body)
+
+	resp, err := doRequest(server.URL+"/users", http.MethodPost, b, authHeader(token))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusCreated, resp.StatusCode)
+
+	var result map[string]any
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&result))
+	assert.Equal(t, "maria@example.com", result["email"])
+	assert.Equal(t, "manager_2", result["role"])
+}
+
+func TestUsersAdmin_Create_DuplicateEmail(t *testing.T) {
+	_, _ = db.Exec(`TRUNCATE TABLE staff CASCADE`)
+	server := setupUsersAdminServer(t)
+	token := generateAdminToken(t)
+
+	body := map[string]interface{}{
+		"first_name": "Иван",
+		"last_name":  "Иванов",
+		"email":      "dup@example.com",
+		"role":       "manager_1",
+	}
+	b, _ := json.Marshal(body)
+
+	resp1, _ := doRequest(server.URL+"/users", http.MethodPost, b, authHeader(token))
+	resp1.Body.Close()
+
+	resp2, err := doRequest(server.URL+"/users", http.MethodPost, b, authHeader(token))
+	require.NoError(t, err)
+	defer resp2.Body.Close()
+	assert.Equal(t, http.StatusConflict, resp2.StatusCode)
+}
+
+func TestUsersAdmin_Create_InvalidRole(t *testing.T) {
+	_, _ = db.Exec(`TRUNCATE TABLE staff CASCADE`)
+	server := setupUsersAdminServer(t)
+	token := generateAdminToken(t)
+
+	body := map[string]interface{}{
+		"first_name": "Иван",
+		"last_name":  "Иванов",
+		"email":      "role@example.com",
+		"role":       "superadmin",
+	}
+	b, _ := json.Marshal(body)
+
+	resp, err := doRequest(server.URL+"/users", http.MethodPost, b, authHeader(token))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+}
+
+func TestUsersAdmin_Create_MissingRequiredFields(t *testing.T) {
+	_, _ = db.Exec(`TRUNCATE TABLE staff CASCADE`)
+	server := setupUsersAdminServer(t)
+	token := generateAdminToken(t)
+
+	body := map[string]interface{}{
+		"first_name": "Иван",
+		"last_name":  "Иванов",
+		"role":       "manager_1",
+	}
+	b, _ := json.Marshal(body)
+
+	resp, err := doRequest(server.URL+"/users", http.MethodPost, b, authHeader(token))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+}
+
+func TestUsersAdmin_Create_Unauthorized(t *testing.T) {
+	server := setupUsersAdminServer(t)
+
+	body := map[string]interface{}{
+		"first_name": "Иван",
+		"last_name":  "Иванов",
+		"email":      "unauth@example.com",
+		"role":       "manager_1",
+	}
+	b, _ := json.Marshal(body)
+
+	resp, err := doRequest(server.URL+"/users", http.MethodPost, b, "")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+}
+
+func TestUsersAdmin_Update_Success(t *testing.T) {
+	_, _ = db.Exec(`TRUNCATE TABLE staff CASCADE`)
+	server := setupUsersAdminServer(t)
+	token := generateAdminToken(t)
+
+	id := seedStaffAdmin(t, "update@example.com")
+
+	body := map[string]interface{}{
+		"first_name": "Обновлённое",
+		"department": "IT",
+		"position":   "Senior",
+		"supervisor": "Начальник",
+		"address":    "Санкт-Петербург",
+	}
+	b, _ := json.Marshal(body)
+
+	resp, err := doRequest(fmt.Sprintf("%s/users/%d", server.URL, id), http.MethodPut, b, authHeader(token))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var result map[string]any
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&result))
+	assert.Equal(t, "Обновлённое", result["name"])
+}
+
+func TestUsersAdmin_Update_NotFound(t *testing.T) {
+	_, _ = db.Exec(`TRUNCATE TABLE staff CASCADE`)
+	server := setupUsersAdminServer(t)
+	token := generateAdminToken(t)
+
+	body := map[string]interface{}{"first_name": "Тест"}
+	b, _ := json.Marshal(body)
+
+	resp, err := doRequest(server.URL+"/users/99999", http.MethodPut, b, authHeader(token))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+}
+
+func TestUsersAdmin_Update_InvalidID(t *testing.T) {
+	server := setupUsersAdminServer(t)
+	token := generateAdminToken(t)
+
+	body := map[string]interface{}{"first_name": "Тест"}
+	b, _ := json.Marshal(body)
+
+	resp, err := doRequest(server.URL+"/users/abc", http.MethodPut, b, authHeader(token))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+}
+
+func TestUsersAdmin_Update_InvalidRole(t *testing.T) {
+	_, _ = db.Exec(`TRUNCATE TABLE staff CASCADE`)
+	server := setupUsersAdminServer(t)
+	token := generateAdminToken(t)
+
+	id := seedStaffAdmin(t, "role_upd@example.com")
+
+	role := "superadmin"
+	body := map[string]interface{}{"role": role}
+	b, _ := json.Marshal(body)
+
+	resp, err := doRequest(fmt.Sprintf("%s/users/%d", server.URL, id), http.MethodPut, b, authHeader(token))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+}
+
+func TestUsersAdmin_Block_Success(t *testing.T) {
+	_, _ = db.Exec(`TRUNCATE TABLE staff CASCADE`)
+	server := setupUsersAdminServer(t)
+	token := generateAdminToken(t)
+
+	id := seedStaffAdmin(t, "block@example.com")
+
+	resp, err := doRequest(fmt.Sprintf("%s/users/%d/block", server.URL, id), http.MethodPut, nil, authHeader(token))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var result map[string]any
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&result))
+	assert.Equal(t, "blocked", result["status"])
+	assert.Equal(t, float64(id), result["id"])
+}
+
+func TestUsersAdmin_Block_UserCannotLoginAfterBlock(t *testing.T) {
+	_, _ = db.Exec(`TRUNCATE TABLE staff CASCADE`)
+	server := setupUsersAdminServer(t)
+	token := generateAdminToken(t)
+
+	hash, _ := bcrypt.GenerateFromPassword([]byte("password123"), bcrypt.MinCost)
+	var id int64
+	err := db.QueryRow(`
+		INSERT INTO staff (first_name, last_name, email, password_hash, role, status)
+		VALUES ('Тест', 'Блок', 'loginblock@example.com', $1, 'manager_1', 'active')
+		RETURNING id`, string(hash)).Scan(&id)
+	require.NoError(t, err)
+
+	resp, err := doRequest(fmt.Sprintf("%s/users/%d/block", server.URL, id), http.MethodPut, nil, authHeader(token))
+	require.NoError(t, err)
+	resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var status string
+	err = db.QueryRow(`SELECT status FROM staff WHERE id = $1`, id).Scan(&status)
+	require.NoError(t, err)
+	assert.Equal(t, "blocked", status)
+}
+
+func TestUsersAdmin_Block_RefreshTokensRevoked(t *testing.T) {
+	_, _ = db.Exec(`TRUNCATE TABLE staff CASCADE`)
+	_, _ = db.Exec(`TRUNCATE TABLE refresh_tokens CASCADE`)
+	server := setupUsersAdminServer(t)
+	token := generateAdminToken(t)
+
+	id := seedStaffAdmin(t, "revoke@example.com")
+
+	_, err := db.Exec(`
+    	INSERT INTO refresh_tokens (user_id, token, expires_at)
+    	VALUES ($1, 'test-refresh-token', NOW() + INTERVAL '7 days')`, id)
+	require.NoError(t, err)
+
+	var count int
+	_ = db.QueryRow(`SELECT COUNT(*) FROM refresh_tokens WHERE user_id = $1`, id).Scan(&count)
+	assert.Equal(t, 1, count)
+
+	resp, err := doRequest(fmt.Sprintf("%s/users/%d/block", server.URL, id), http.MethodPut, nil, authHeader(token))
+	require.NoError(t, err)
+	resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	_ = db.QueryRow(`SELECT COUNT(*) FROM refresh_tokens WHERE user_id = $1`, id).Scan(&count)
+	assert.Equal(t, 0, count)
+}
+
+func TestUsersAdmin_Block_NotFound(t *testing.T) {
+	_, _ = db.Exec(`TRUNCATE TABLE staff CASCADE`)
+	server := setupUsersAdminServer(t)
+	token := generateAdminToken(t)
+
+	resp, err := doRequest(server.URL+"/users/99999/block", http.MethodPut, nil, authHeader(token))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+}
+
+func TestUsersAdmin_Block_InvalidID(t *testing.T) {
+	server := setupUsersAdminServer(t)
+	token := generateAdminToken(t)
+
+	resp, err := doRequest(server.URL+"/users/abc/block", http.MethodPut, nil, authHeader(token))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+}
+
+func seedStaffAdmin(t *testing.T, email string) int64 {
+	t.Helper()
+	var id int64
+	err := db.QueryRow(`
+		INSERT INTO staff (first_name, last_name, email, role, status)
+		VALUES ('Тест', 'Тестов', $1, 'manager_1', 'active')
+		RETURNING id`, email).Scan(&id)
+	require.NoError(t, err)
+	return id
+}
+
+func doRequest(url, method string, body []byte, auth string) (*http.Response, error) {
+	var req *http.Request
+	var err error
+
+	if body != nil {
+		req, err = http.NewRequest(method, url, bytes.NewReader(body))
+	} else {
+		req, err = http.NewRequest(method, url, nil)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	if auth != "" {
+		req.Header.Set("Authorization", auth)
+	}
+
+	return http.DefaultClient.Do(req)
+}

--- a/internal/api/server/routes.go
+++ b/internal/api/server/routes.go
@@ -7,7 +7,7 @@ import (
 	"github.com/yandex-development-1-team/go/internal/api/middleware"
 )
 
-func SetupRoutes(router *gin.Engine, jwtSecret []byte, authHandler *handlers.AuthHandler, boxHandler *handlers.BoxHandler, specProjHandler *handlers.SpecialProjectHandler, settingsHandler *handlers.SettingsHandler, analyticsHandler *handlers.AnalyticsHandler, recPageHandler *handlers.ResourcePageHandler, userHandler *handlers.UserHandler, fileHandler *handlers.FileHandler, applicationHandler *handlers.ApplicationHandler, usersHandler *handlers.UsersHandler) {
+func SetupRoutes(router *gin.Engine, jwtSecret []byte, authHandler *handlers.AuthHandler, boxHandler *handlers.BoxHandler, specProjHandler *handlers.SpecialProjectHandler, settingsHandler *handlers.SettingsHandler, analyticsHandler *handlers.AnalyticsHandler, recPageHandler *handlers.ResourcePageHandler, userHandler *handlers.UserHandler, fileHandler *handlers.FileHandler, applicationHandler *handlers.ApplicationHandler, usersHandler *handlers.UsersHandler, bookingHandler *handlers.BookingHandler) {
 	apiV1 := router.Group("/api/v1")
 	{
 		setupAuthRoutes(apiV1, authHandler)
@@ -24,9 +24,11 @@ func SetupRoutes(router *gin.Engine, jwtSecret []byte, authHandler *handlers.Aut
 			setupFileRoutes(protected, fileHandler)
 			setupApplicationRoutes(protected, applicationHandler)
 			setupUsersAdminRoutes(protected, usersHandler)
+			setupBookingRoutes(protected, bookingHandler)
 		}
 		public := apiV1.Group("/public")
 		public.GET("/resources/:slug", recPageHandler.GetPublicBySlug)
+		public.POST("/applications/", applicationHandler.Create)
 	}
 }
 
@@ -48,6 +50,8 @@ func setupSpecialProjectRoutes(rg *gin.RouterGroup, h *handlers.SpecialProjectHa
 		sp.GET("/", h.ListSpecialProjects)
 		sp.POST("/", h.CreateSpecialProject)
 		sp.GET("/:id", h.GetSpecialProjectByID)
+		sp.PUT("/:id", h.UpdateSpecialProject)
+		sp.DELETE("/:id", h.DeleteSpecialProject)
 	}
 }
 
@@ -62,7 +66,7 @@ func setupBoxRoutes(rg *gin.RouterGroup, boxHandler *handlers.BoxHandler) {
 	boxes := rg.Group("/boxes")
 	{
 		boxes.GET("/", boxHandler.List)
-		boxes.POST("/")
+		boxes.POST("/", boxHandler.Create)
 		boxes.GET("/:id", boxHandler.GetByID)
 		boxes.PUT("/:id", boxHandler.Update)
 		boxes.DELETE("/:id", boxHandler.Delete)
@@ -108,11 +112,10 @@ func setupFileRoutes(rg *gin.RouterGroup, h *handlers.FileHandler) {
 func setupApplicationRoutes(rg *gin.RouterGroup, h *handlers.ApplicationHandler) {
 	applications := rg.Group("/applications")
 	{
-		applications.GET("/", h.List)
-		applications.POST("/", h.Create)
+		applications.GET("/", h.ApplicationsList)
 		applications.GET("/:id", h.GetByID)
-		applications.PUT("/:id", h.Update)
-		applications.DELETE("/:id", h.Delete)
+		applications.PUT("/:id/status", h.UpdateApplicationStatus)
+		applications.DELETE("/:id", h.DeleteApplication)
 	}
 }
 
@@ -122,6 +125,15 @@ func setupUsersAdminRoutes(rg *gin.RouterGroup, h *handlers.UsersHandler) {
 	{
 		users.POST("", h.Create)
 		users.PUT("/:id", h.Update)
-		users.PUT("/id/block", h.Block)
+		users.PUT("/:id/block", h.Block)
+	}
+}
+func setupBookingRoutes(rg *gin.RouterGroup, h *handlers.BookingHandler) {
+	bookings := rg.Group("/bookings")
+	{
+		bookings.GET("/", h.BookingsList)
+		bookings.GET("/:id", h.BookingsById)
+		bookings.PUT("/:id/status", h.UpdateBookingStatus)
+		bookings.DELETE("/:id", h.DeleteBooking)
 	}
 }

--- a/internal/api/server/routes.go
+++ b/internal/api/server/routes.go
@@ -7,7 +7,7 @@ import (
 	"github.com/yandex-development-1-team/go/internal/api/middleware"
 )
 
-func SetupRoutes(router *gin.Engine, jwtSecret []byte, authHandler *handlers.AuthHandler, boxHandler *handlers.BoxHandler, specProjHandler *handlers.SpecialProjectHandler, settingsHandler *handlers.SettingsHandler, analyticsHandler *handlers.AnalyticsHandler, recPageHandler *handlers.ResourcePageHandler, userHandler *handlers.UserHandler, fileHandler *handlers.FileHandler, applicationHandler *handlers.ApplicationHandler) {
+func SetupRoutes(router *gin.Engine, jwtSecret []byte, authHandler *handlers.AuthHandler, boxHandler *handlers.BoxHandler, specProjHandler *handlers.SpecialProjectHandler, settingsHandler *handlers.SettingsHandler, analyticsHandler *handlers.AnalyticsHandler, recPageHandler *handlers.ResourcePageHandler, userHandler *handlers.UserHandler, fileHandler *handlers.FileHandler, applicationHandler *handlers.ApplicationHandler, usersHandler *handlers.UsersHandler) {
 	apiV1 := router.Group("/api/v1")
 	{
 		setupAuthRoutes(apiV1, authHandler)
@@ -23,6 +23,7 @@ func SetupRoutes(router *gin.Engine, jwtSecret []byte, authHandler *handlers.Aut
 			setupResourcesRoutes(protected, recPageHandler)
 			setupFileRoutes(protected, fileHandler)
 			setupApplicationRoutes(protected, applicationHandler)
+			setupUsersAdminRoutes(protected, usersHandler)
 		}
 		public := apiV1.Group("/public")
 		public.GET("/resources/:slug", recPageHandler.GetPublicBySlug)
@@ -112,5 +113,15 @@ func setupApplicationRoutes(rg *gin.RouterGroup, h *handlers.ApplicationHandler)
 		applications.GET("/:id", h.GetByID)
 		applications.PUT("/:id", h.Update)
 		applications.DELETE("/:id", h.Delete)
+	}
+}
+
+func setupUsersAdminRoutes(rg *gin.RouterGroup, h *handlers.UsersHandler) {
+	users := rg.Group("/users")
+	users.Use(middleware.RequireAdmin())
+	{
+		users.POST("", h.Create)
+		users.PUT("/:id", h.Update)
+		users.PUT("/id/block", h.Block)
 	}
 }

--- a/internal/api/server/server.go
+++ b/internal/api/server/server.go
@@ -24,6 +24,7 @@ type APIServices struct {
 	UserSvc           *apiService.UserService
 	FileService       *apiService.FileService
 	ApplicationRepo   repository.ApplicationRepository
+	UsersAdmin        *apiService.UsersAdminService
 }
 
 type Server struct {
@@ -63,8 +64,9 @@ func (s *Server) RegisterRoutes() {
 	userHandler := handlers.NewUserHandler(s.services.UserSvc)
 	fileHandler := handlers.NewFileHandler(s.services.FileService)
 	applicationHandler := handlers.NewApplicationHandler(s.services.ApplicationRepo)
+	usersHandler := handlers.NewUsersHandler(s.services.UsersAdmin)
 
-	SetupRoutes(s.router, s.authService.JwtSecret, authHandler, boxHandler, specProjHandler, settingsHandler, analyticsHandler, recPageHandler, userHandler, fileHandler, applicationHandler)
+	SetupRoutes(s.router, s.authService.JwtSecret, authHandler, boxHandler, specProjHandler, settingsHandler, analyticsHandler, recPageHandler, userHandler, fileHandler, applicationHandler, usersHandler)
 }
 
 func (s *Server) Run(cfg *config.Config) error {

--- a/internal/api/server/server.go
+++ b/internal/api/server/server.go
@@ -10,7 +10,6 @@ import (
 	"github.com/yandex-development-1-team/go/internal/api/handlers"
 	"github.com/yandex-development-1-team/go/internal/api/middleware"
 	"github.com/yandex-development-1-team/go/internal/config"
-	"github.com/yandex-development-1-team/go/internal/repository"
 	"github.com/yandex-development-1-team/go/internal/service"
 	apiService "github.com/yandex-development-1-team/go/internal/service/api"
 )
@@ -23,8 +22,9 @@ type APIServices struct {
 	RecPageSvc        *service.ResourcePageService
 	UserSvc           *apiService.UserService
 	FileService       *apiService.FileService
-	ApplicationRepo   repository.ApplicationRepository
 	UsersAdmin        *apiService.UsersAdminService
+	ApplicationSvc    *apiService.ApplicationsService
+	BookingSvc        *apiService.BookingsService
 }
 
 type Server struct {
@@ -54,7 +54,7 @@ func New(cfg *config.Config, services *APIServices, authService *apiService.Auth
 	}
 }
 
-func (s *Server) RegisterRoutes() {
+func (s *Server) RegisterRoutes(yandexFormToken string) {
 	authHandler := handlers.NewAuthHandler(s.authService)
 	boxHandler := handlers.NewBoxHandler(s.services.BoxService)
 	specProjHandler := handlers.NewSpecialProjectHandler(s.services.SpecialProjectSvc)
@@ -63,10 +63,11 @@ func (s *Server) RegisterRoutes() {
 	recPageHandler := handlers.NewResourcePageHandler(s.services.RecPageSvc)
 	userHandler := handlers.NewUserHandler(s.services.UserSvc)
 	fileHandler := handlers.NewFileHandler(s.services.FileService)
-	applicationHandler := handlers.NewApplicationHandler(s.services.ApplicationRepo)
 	usersHandler := handlers.NewUsersHandler(s.services.UsersAdmin)
+	applicationHandler := handlers.NewApplicationHandler(s.services.ApplicationSvc, yandexFormToken)
+	bookingHamdler := handlers.NewBookingHandler(s.services.BookingSvc)
 
-	SetupRoutes(s.router, s.authService.JwtSecret, authHandler, boxHandler, specProjHandler, settingsHandler, analyticsHandler, recPageHandler, userHandler, fileHandler, applicationHandler, usersHandler)
+	SetupRoutes(s.router, s.authService.JwtSecret, authHandler, boxHandler, specProjHandler, settingsHandler, analyticsHandler, recPageHandler, userHandler, fileHandler, applicationHandler, usersHandler, bookingHamdler)
 }
 
 func (s *Server) Run(cfg *config.Config) error {

--- a/internal/dto/application.go
+++ b/internal/dto/application.go
@@ -10,7 +10,6 @@ const (
 type ApplicationListQuery struct {
 	Status       *string `form:"status" binding:"omitempty,oneof=queue in_progress done"`
 	Type         *string `form:"type" binding:"omitempty,oneof=box special_project"`
-	ManagerID    *int64  `form:"manager_id" binding:"omitempty,min=1"`
 	CustomerName string  `form:"customer_name"`
 	Limit        int     `form:"limit" binding:"omitempty,min=1,max=100"`
 	Offset       int     `form:"offset" binding:"omitempty,min=0"`

--- a/internal/dto/application.go
+++ b/internal/dto/application.go
@@ -1,21 +1,93 @@
 package dto
 
-import "github.com/yandex-development-1-team/go/internal/models"
+import (
+	"time"
+)
 
 const (
 	DefaultApplicationLimit = 20
 	MaxApplicationLimit     = 100
 )
 
-type ApplicationListQuery struct {
-	Status       *string `form:"status" binding:"omitempty,oneof=queue in_progress done"`
-	Type         *string `form:"type" binding:"omitempty,oneof=box special_project"`
-	CustomerName string  `form:"customer_name"`
+type ApplicationUpdateStatus struct {
+	Status string `json:"status" binding:"required,oneof=pending confirmed cancelled"`
+}
+
+type Application struct {
+	ID           int64     `json:"id"`
+	Status       string    `json:"status"`
+	ManagerID    int64     `json:"manager_id"`
+	ManagerName  string    `json:"manager_name"`
+	FormAnswerId string    `json:"form_answer_id"`
+	CustomerName string    `json:"customer_name"`
+	ContactInfo  string    `json:"contact_info"`
+	Description  string    `json:"description"`
+	CreatedAt    time.Time `json:"created_at"`
+	UpdatedAt    time.Time `json:"updated_at"`
+}
+
+type ApplicationDB struct {
+	ID           int64     `db:"id"`
+	Status       string    `db:"status"`
+	ManagerID    int64     `db:"manager_id"`
+	ManagerName  string    `db:"manager_name"`
+	FormAnswerId string    `db:"form_answer_id"`
+	CustomerName string    `db:"customer_name"`
+	ContactInfo  string    `db:"contact_info"`
+	Description  string    `db:"description"`
+	CreatedAt    time.Time `db:"created_at"`
+	UpdatedAt    time.Time `db:"updated_at"`
+}
+
+type CreateApplicationRequest struct {
+	Answer struct {
+		Data struct {
+			FirstName struct {
+				Value string `json:"value"`
+			} `json:"first_name"`
+			LastName struct {
+				Value string `json:"value"`
+			} `json:"last_name"`
+			Telegram struct {
+				Value string `json:"value"`
+			} `json:"telegram"`
+			Description struct {
+				Value string `json:"value"`
+			} `json:"description"`
+		} `json:"data"`
+	} `json:"answer"`
+}
+
+type ApplicationListRequest struct {
+	Status       *string `form:"status" binding:"omitempty,oneof=pending confirmed cancelled"`
+	ManagerID    *int64  `form:"manager_id" binding:"omitempty,min=1"`
+	CustomerName *string `form:"customer_name"`
 	Limit        int     `form:"limit" binding:"omitempty,min=1,max=100"`
 	Offset       int     `form:"offset" binding:"omitempty,min=0"`
 }
 
+type ApplicationListItem struct {
+	ID           int64     `json:"id"`
+	Status       string    `json:"status"`
+	ManagerID    int64     `json:"manager_id"`
+	ManagerName  string    `json:"manager_name"`
+	CustomerName string    `json:"customer_name"`
+	ContactInfo  string    `json:"contact_info"`
+	CreatedAt    time.Time `json:"created_at"`
+}
+
 type ApplicationListResponse struct {
-	Items      []models.Application `json:"items"`
-	Pagination Pagination           `json:"pagination"`
+	Items      []ApplicationListItem `json:"items"`
+	Pagination Pagination            `json:"pagination"`
+}
+
+type ApplicationRow struct {
+	ID           int64     `db:"id"`
+	Status       string    `db:"status"`
+	ManagerID    int64     `db:"manager_id"`
+	ManagerName  string    `db:"manager_name"`
+	CustomerName string    `db:"customer_name"`
+	ContactInfo  string    `db:"contact_info"`
+	CreatedAt    time.Time `db:"created_at"`
+	Total        int       `db:"total"`
 }

--- a/internal/dto/auth.go
+++ b/internal/dto/auth.go
@@ -2,8 +2,6 @@ package dto
 
 import (
 	"time"
-
-	"github.com/lib/pq"
 )
 
 type LoginRequest struct {
@@ -29,31 +27,27 @@ type UserResponse struct {
 	Status       string    `json:"status"`
 	Department   string    `json:"department"`
 	Position     string    `json:"position"`
-	ManagerID    int64     `json:"manager_id"`
 	InviteToken  string    `json:"invite_token"`
-	Permissions  []string  `json:"permissions"`
 	CreatedAt    time.Time `json:"created_at"`
 	UpdatedAt    time.Time `json:"updated_at"`
 }
 
 type UserRow struct {
-	ID           int64          `db:"id"`
-	TelegramNick *string        `db:"telegram_nick"`
-	Name         string         `db:"first_name"`
-	LastName     string         `db:"last_name"`
-	SecondName   string         `db:"second_name"`
-	Email        string         `db:"email"`
-	PhoneNumber  *string        `db:"phone_number"`
-	UserPass     string         `db:"password_hash"`
-	Role         string         `db:"role"`
-	Status       string         `db:"status"`
-	InviteToken  *string        `db:"invite_token"`
-	Department   *string        `db:"department"`
-	Position     *string        `db:"position"`
-	ManagerID    *int64         `db:"manager_id"`
-	Permissions  pq.StringArray `db:"permissions"`
-	CreatedAt    time.Time      `db:"created_at"`
-	UpdatedAt    time.Time      `db:"updated_at"`
+	ID           int64     `db:"id"`
+	TelegramNick *string   `db:"telegram_nick"`
+	Name         string    `db:"first_name"`
+	LastName     string    `db:"last_name"`
+	SecondName   string    `db:"second_name"`
+	Email        string    `db:"email"`
+	PhoneNumber  *string   `db:"phone_number"`
+	UserPass     string    `db:"password_hash"`
+	Role         string    `db:"role"`
+	Status       string    `db:"status"`
+	InviteToken  *string   `db:"invite_token"`
+	Department   *string   `db:"department"`
+	Position     *string   `db:"position"`
+	CreatedAt    time.Time `db:"created_at"`
+	UpdatedAt    time.Time `db:"updated_at"`
 }
 
 type RefreshRequest struct {

--- a/internal/dto/auth.go
+++ b/internal/dto/auth.go
@@ -27,6 +27,8 @@ type UserResponse struct {
 	Status       string    `json:"status"`
 	Department   string    `json:"department"`
 	Position     string    `json:"position"`
+	Supervisor   string    `db:"supervisor"`
+	Address      string    `db:"address"`
 	InviteToken  string    `json:"invite_token"`
 	CreatedAt    time.Time `json:"created_at"`
 	UpdatedAt    time.Time `json:"updated_at"`
@@ -46,6 +48,8 @@ type UserRow struct {
 	InviteToken  *string   `db:"invite_token"`
 	Department   *string   `db:"department"`
 	Position     *string   `db:"position"`
+	Supervisor   *string   `db:"supervisor"`
+	Address      *string   `db:"address"`
 	CreatedAt    time.Time `db:"created_at"`
 	UpdatedAt    time.Time `db:"updated_at"`
 }

--- a/internal/dto/users.go
+++ b/internal/dto/users.go
@@ -2,6 +2,30 @@ package dto
 
 import "time"
 
+type UserCreateRequest struct {
+	TelegramNick *string  `json:"telegram_nick,omitempty"`
+	Name         string   `json:"name" binding:"required,min=1"`
+	Email        string   `json:"email" binding:"required,email"`
+	Role         string   `json:"role" binding:"required"`
+	Status       string   `json:"status,omitempty"`
+	Permissions  []string `json:"permissions,omitempty"`
+}
+
+type UserUpdateRequest struct {
+	Name         *string   `json:"name,omitempty"`
+	Email        *string   `json:"email,omitempty"`
+	Role         *string   `json:"role,omitempty"`
+	Status       *string   `json:"status,omitempty"`
+	Permissions  *[]string `json:"permissions,omitempty"`
+	TelegramNick *string   `json:"telegram_nick,omitempty"`
+}
+
+type BlockResponse struct {
+	ID        int64     `json:"id"`
+	Status    string    `json:"status"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
 type UserListItem struct {
 	ID           int64     `json:"id"`
 	TelegramNick string    `json:"telegram_nick"`

--- a/internal/dto/users.go
+++ b/internal/dto/users.go
@@ -3,19 +3,27 @@ package dto
 import "time"
 
 type UserCreateRequest struct {
-	TelegramNick *string `json:"telegram_nick,omitempty"`
-	Name         string  `json:"name" binding:"required,min=1"`
-	Email        string  `json:"email" binding:"required,email"`
-	Role         string  `json:"role" binding:"required"`
-	Status       string  `json:"status,omitempty"`
+	FirstName  string  `json:"first_name"`
+	LastName   string  `json:"last_name"`
+	Email      string  `json:"email" binding:"required,email"`
+	Role       string  `json:"role" binding:"required"`
+	Status     string  `json:"status,omitempty"`
+	Phone      *string `json:"phone,omitempty"`
+	Department *string `json:"department,omitempty"`
+	Position   *string `json:"position,omitempty"`
+	SecondName *string `json:"second_name,omitempty"`
 }
 
 type UserUpdateRequest struct {
-	Name         *string `json:"name,omitempty"`
-	Email        *string `json:"email,omitempty"`
-	Role         *string `json:"role,omitempty"`
-	Status       *string `json:"status,omitempty"`
-	TelegramNick *string `json:"telegram_nick,omitempty"`
+	FirstName  *string `json:"first_name,omitempty"`
+	LastName   *string `json:"last_name,omitempty"`
+	Email      *string `json:"email,omitempty"`
+	Role       *string `json:"role,omitempty"`
+	Status     *string `json:"status,omitempty"`
+	Phone      *string `json:"phone_number,omitempty"`
+	Department *string `json:"department,omitempty"`
+	Position   *string `json:"position,omitempty"`
+	SecondName *string `json:"second_name,omitempty"`
 }
 
 type BlockResponse struct {

--- a/internal/dto/users.go
+++ b/internal/dto/users.go
@@ -3,21 +3,19 @@ package dto
 import "time"
 
 type UserCreateRequest struct {
-	TelegramNick *string  `json:"telegram_nick,omitempty"`
-	Name         string   `json:"name" binding:"required,min=1"`
-	Email        string   `json:"email" binding:"required,email"`
-	Role         string   `json:"role" binding:"required"`
-	Status       string   `json:"status,omitempty"`
-	Permissions  []string `json:"permissions,omitempty"`
+	TelegramNick *string `json:"telegram_nick,omitempty"`
+	Name         string  `json:"name" binding:"required,min=1"`
+	Email        string  `json:"email" binding:"required,email"`
+	Role         string  `json:"role" binding:"required"`
+	Status       string  `json:"status,omitempty"`
 }
 
 type UserUpdateRequest struct {
-	Name         *string   `json:"name,omitempty"`
-	Email        *string   `json:"email,omitempty"`
-	Role         *string   `json:"role,omitempty"`
-	Status       *string   `json:"status,omitempty"`
-	Permissions  *[]string `json:"permissions,omitempty"`
-	TelegramNick *string   `json:"telegram_nick,omitempty"`
+	Name         *string `json:"name,omitempty"`
+	Email        *string `json:"email,omitempty"`
+	Role         *string `json:"role,omitempty"`
+	Status       *string `json:"status,omitempty"`
+	TelegramNick *string `json:"telegram_nick,omitempty"`
 }
 
 type BlockResponse struct {

--- a/internal/dto/users.go
+++ b/internal/dto/users.go
@@ -11,6 +11,8 @@ type UserCreateRequest struct {
 	Phone      *string `json:"phone,omitempty"`
 	Department *string `json:"department,omitempty"`
 	Position   *string `json:"position,omitempty"`
+	Supervisor *string `json:"supervisor,omitempty"`
+	Address    *string `json:"address,omitempty"`
 	SecondName *string `json:"second_name,omitempty"`
 }
 
@@ -23,6 +25,8 @@ type UserUpdateRequest struct {
 	Phone      *string `json:"phone_number,omitempty"`
 	Department *string `json:"department,omitempty"`
 	Position   *string `json:"position,omitempty"`
+	Supervisor *string `json:"supervisor,omitempty"`
+	Address    *string `json:"address,omitempty"`
 	SecondName *string `json:"second_name,omitempty"`
 }
 
@@ -71,6 +75,8 @@ type UserWithDetails struct {
 	Status        string             `json:"status"`
 	Department    string             `json:"department"`
 	Position      string             `json:"position"`
+	Supervisor    string             `json:"supervisor"`
+	Address       string             `json:"address"`
 	CreatedAt     time.Time          `json:"created_at"`
 	UpdatedAt     time.Time          `json:"updated_at"`
 	Bookings      []UserBookingItem  `json:"bookings"`

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -88,9 +88,7 @@ type UserAPI struct {
 	Status       string
 	Department   string
 	Position     string
-	ManagerID    int64
 	InviteToken  string
-	Permissions  []string
 	CreatedAt    time.Time
 	UpdatedAt    time.Time
 }
@@ -185,7 +183,6 @@ type Application struct {
 	ProjectName      *string           `db:"project_name" json:"project_name,omitempty"`
 	BoxID            *int64            `db:"box_id" json:"box_id,omitempty"`
 	SpecialProjectID *int64            `db:"special_project_id" json:"special_project_id,omitempty"`
-	ManagerID        *int64            `db:"manager_id" json:"manager_id,omitempty"`
 	ManagerName      *string           `db:"manager_name" json:"manager_name,omitempty"`
 	CreatedAt        time.Time         `db:"created_at" json:"created_at"`
 	UpdatedAt        time.Time         `db:"updated_at" json:"updated_at"`
@@ -204,7 +201,6 @@ type ApplicationCreateRequest struct {
 type ApplicationFilter struct {
 	Type         *ApplicationType
 	Status       *ApplicationStatus
-	ManagerID    *int64
 	CustomerName string
 	DateFrom     *time.Time
 	DateTo       *time.Time
@@ -244,7 +240,6 @@ type StaffAdminCreate struct {
 	Email        string
 	Role         string
 	Status       string
-	Permissions  []string
 	TelegramNick *string
 	InviteToken  string
 }
@@ -254,6 +249,5 @@ type StaffAdminUpdate struct {
 	Email        *string
 	Role         *string
 	Status       *string
-	Permissions  *[]string
 	TelegramNick *string
 }

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -238,3 +238,22 @@ type RefreshResponse struct {
 	Token        string
 	RefreshToken string
 }
+
+type StaffAdminCreate struct {
+	Name         string
+	Email        string
+	Role         string
+	Status       string
+	Permissions  []string
+	TelegramNick *string
+	InviteToken  string
+}
+
+type StaffAdminUpdate struct {
+	Name         *string
+	Email        *string
+	Role         *string
+	Status       *string
+	Permissions  *[]string
+	TelegramNick *string
+}

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -13,7 +13,7 @@ const (
 	PermBoxesEdit         = "boxes:edit"
 	PermBoxesDelete       = "boxes:delete"
 	PermSpecProjectView   = "specproject:view"
-	PermSpecPrijectEdit   = "specproject:edit"
+	PermSpecProjectEdit   = "specproject:edit"
 	PermSpecProjectDelete = "specproject:delete"
 	PermAnalyticsView     = "analytics:view"
 	PermAnalyticsDownload = "analytics:download"
@@ -236,18 +236,26 @@ type RefreshResponse struct {
 }
 
 type StaffAdminCreate struct {
-	Name         string
-	Email        string
-	Role         string
-	Status       string
-	TelegramNick *string
-	InviteToken  string
+	FirstName   string
+	LastName    string
+	SecondName  string
+	Email       string
+	Role        string
+	Status      string
+	PhoneNumber *string
+	Department  *string
+	Position    *string
+	InviteToken string
 }
 
 type StaffAdminUpdate struct {
-	Name         *string
-	Email        *string
-	Role         *string
-	Status       *string
-	TelegramNick *string
+	FirstName   *string
+	LastName    *string
+	SecondName  *string
+	Email       *string
+	Role        *string
+	Status      *string
+	PhoneNumber *string
+	Department  *string
+	Position    *string
 }

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -45,6 +45,10 @@ var (
 	ErrSlotsNotFound          = errors.New("slots not found")
 )
 
+type ApplicationURI struct {
+	ID int64 `uri:"id" binding:"required,min=1"`
+}
+
 type RefreshToken struct {
 	ID        int64     `db:"id"`
 	UserID    int64     `db:"user_id"`
@@ -89,6 +93,8 @@ type UserAPI struct {
 	Department   string
 	Position     string
 	InviteToken  string
+	Supervisor   string
+	Address      string
 	CreatedAt    time.Time
 	UpdatedAt    time.Time
 }
@@ -106,10 +112,11 @@ type AuthResult struct {
 	RefreshToken string   `json:"refresh_token"`
 }
 
-type Booking struct {
+type BookingExt struct {
 	ID                int64      `db:"id"`
 	UserID            int64      `db:"user_id"`
 	ServiceID         int16      `db:"service_id"`
+	ServiceName       string     `db:"service_name"`
 	BookingDate       time.Time  `db:"booking_date"`
 	BookingTime       *time.Time `db:"booking_time"`
 	GuestName         string     `db:"guest_name"`
@@ -131,105 +138,6 @@ type UserSession struct {
 	UpdatedAt    time.Time              `json:"updated_at"`
 }
 
-type (
-	ApplicationType   string
-	ApplicationSource string
-	ApplicationStatus string
-)
-
-const (
-	ApplicationTypeBox            ApplicationType = "box"
-	ApplicationTypeSpecialProject ApplicationType = "special_project"
-
-	ApplicationSourceTelegramBot ApplicationSource = "telegram_bot"
-	ApplicationSourceManual      ApplicationSource = "manual"
-
-	ApplicationStatusQueue      ApplicationStatus = "queue"
-	ApplicationStatusInProgress ApplicationStatus = "in_progress"
-	ApplicationStatusDone       ApplicationStatus = "done"
-)
-
-func (t ApplicationType) Valid() bool {
-	switch t {
-	case ApplicationTypeBox, ApplicationTypeSpecialProject:
-		return true
-	}
-	return false
-}
-
-func (s ApplicationSource) Valid() bool {
-	switch s {
-	case ApplicationSourceTelegramBot, ApplicationSourceManual:
-		return true
-	}
-	return false
-}
-
-func (s ApplicationStatus) Valid() bool {
-	switch s {
-	case ApplicationStatusQueue, ApplicationStatusInProgress, ApplicationStatusDone:
-		return true
-	}
-	return false
-}
-
-type Application struct {
-	ID               int64             `db:"id" json:"id"`
-	Type             ApplicationType   `db:"type" json:"type"`
-	Source           ApplicationSource `db:"source" json:"source"`
-	Status           ApplicationStatus `db:"status" json:"status"`
-	CustomerName     string            `db:"customer_name" json:"customer_name"`
-	ContactInfo      string            `db:"contact_info" json:"contact_info"`
-	ProjectName      *string           `db:"project_name" json:"project_name,omitempty"`
-	BoxID            *int64            `db:"box_id" json:"box_id,omitempty"`
-	SpecialProjectID *int64            `db:"special_project_id" json:"special_project_id,omitempty"`
-	ManagerName      *string           `db:"manager_name" json:"manager_name,omitempty"`
-	CreatedAt        time.Time         `db:"created_at" json:"created_at"`
-	UpdatedAt        time.Time         `db:"updated_at" json:"updated_at"`
-}
-
-type ApplicationCreateRequest struct {
-	Type             ApplicationType   `json:"type"`
-	Source           ApplicationSource `json:"source"`
-	CustomerName     string            `json:"customer_name"`
-	ContactInfo      string            `json:"contact_info"`
-	ProjectName      *string           `json:"project_name,omitempty"`
-	BoxID            *int64            `json:"box_id,omitempty"`
-	SpecialProjectID *int64            `json:"special_project_id,omitempty"`
-}
-
-type ApplicationFilter struct {
-	Type         *ApplicationType
-	Status       *ApplicationStatus
-	CustomerName string
-	DateFrom     *time.Time
-	DateTo       *time.Time
-	Limit        int
-	Offset       int
-}
-
-type Pagination struct {
-	Total  int `json:"total"`
-	Limit  int `json:"limit"`
-	Offset int `json:"offset"`
-}
-
-type ApplicationListResponse struct {
-	Items      []Application `json:"items"`
-	Pagination Pagination    `json:"pagination"`
-}
-
-type ApplicationUpdateRequest struct {
-	Status           *ApplicationStatus `json:"status,omitempty"`
-	ContactInfo      *string            `json:"contact_info,omitempty"`
-	BoxID            *int64             `json:"box_id,omitempty"`
-	SpecialProjectID *int64             `json:"special_project_id,omitempty"`
-}
-
-func (r *ApplicationUpdateRequest) HasUpdates() bool {
-	return r.Status != nil || r.ContactInfo != nil || r.BoxID != nil || r.SpecialProjectID != nil
-}
-
 type RefreshResponse struct {
 	Token        string
 	RefreshToken string
@@ -245,6 +153,8 @@ type StaffAdminCreate struct {
 	PhoneNumber *string
 	Department  *string
 	Position    *string
+	Supervisor  *string
+	Address     *string
 	InviteToken string
 }
 
@@ -258,4 +168,6 @@ type StaffAdminUpdate struct {
 	PhoneNumber *string
 	Department  *string
 	Position    *string
+	Supervisor  *string
+	Address     *string
 }

--- a/internal/repository/interfaces.go
+++ b/internal/repository/interfaces.go
@@ -17,6 +17,9 @@ type StaffRepository interface {
 	CreateStaff(ctx context.Context, userReq *models.UserAPI, hashPassword string) (*models.UserAPI, error)
 	List(ctx context.Context, role, status, search string, limit, offset int) ([]dto.UserListItem, int, error)
 	GetByID(ctx context.Context, id int64) (*dto.UserWithDetails, error)
+	CreateStaffByAdmin(ctx context.Context, req *models.StaffAdminCreate) (*models.UserAPI, error)
+	UpdateStaff(ctx context.Context, id int64, req *models.StaffAdminUpdate) (*models.UserAPI, error)
+	BlockStaff(ctx context.Context, id int64) (*models.UserAPI, error)
 }
 
 type TelegramUserRepository interface {
@@ -85,7 +88,7 @@ type PasswordResetRepository interface {
 type SpecialProjectRepository interface {
 	Create(ctx context.Context, proj *models.SpecialProjectDB) (*models.SpecialProjectDB, error)
 	GetByID(ctx context.Context, id int64) (*models.SpecialProjectDB, error)
-	List(ctx context.Context, statusFilter *bool, searchQuery string, limit, offset int) ([]*models.SpecialProjectDB, int, error)
+	List(ctx context.Context, statusFilter string, searchQuery string, limit, offset int) ([]*models.SpecialProjectDB, int, error)
 	Update(ctx context.Context, id int64, update *models.SpecialProjectUpdate) (*models.SpecialProjectDB, error)
 	Delete(ctx context.Context, id int64) error
 }
@@ -95,11 +98,11 @@ type TxRepository interface {
 }
 
 type ResourcePageRepository interface {
-	GetAll(ctx context.Context) ([]models.ResourcePage, error)
 	GetBySlug(ctx context.Context, slug string) (*models.ResourcePage, error)
-	Update(ctx context.Context, slug string, page models.ResourcePage) (*models.ResourcePage, error)
-	Clear(ctx context.Context, slug string) (*models.ResourcePage, error)
-	DeleteLink(ctx context.Context, slug string, id string) (*models.ResourcePage, error)
+	GetBySlugTx(ctx context.Context, queryable Queryable, slug string, lockForUpdate bool) (*models.ResourcePage, error)
+	UpdatePageContentAndLinksTx(ctx context.Context, tx *sqlx.Tx, slug string, title string, content string, links []models.ResourcePageLink) error
+	GetAllSummaries(ctx context.Context) ([]*models.ResourcePage, error)
+	BeginTx(ctx context.Context) (*sqlx.Tx, error)
 }
 
 type Queryable interface {

--- a/internal/repository/interfaces.go
+++ b/internal/repository/interfaces.go
@@ -34,13 +34,16 @@ type BookingRepository interface {
 	GetAvailableSlots(ctx context.Context, serviceID int, date time.Time) ([]time.Time, error)
 	GetBookingsByUserID(ctx context.Context, userID int64) ([]models.Booking, error)
 	UpdateBookingStatus(ctx context.Context, bookingID int64, status string) error
+	GetBookingById(ctx context.Context, id int64) (*models.BookingAPI, error)
+	GetBookingsList(ctx context.Context, filter *models.ApplicationFilter) (*models.BookingList, error)
+	DeleteBooking(ctx context.Context, id int64) error
 }
 
 type ApplicationRepository interface {
-	CreateApplication(ctx context.Context, req *models.ApplicationCreateRequest) (*models.Application, error)
-	GetApplications(ctx context.Context, filter models.ApplicationFilter) ([]models.Application, int, error)
+	CreateApplication(ctx context.Context, req *models.Application) error
 	GetApplicationByID(ctx context.Context, id int64) (*models.Application, error)
-	UpdateApplication(ctx context.Context, id int64, req *models.ApplicationUpdateRequest) (*models.Application, error)
+	UpdateApplicationStatus(ctx context.Context, id int64, status string) error
+	ApplicationsList(ctx context.Context, filter *models.ApplicationFilter) (*models.ApplicationList, error)
 	DeleteApplication(ctx context.Context, id int64) error
 }
 
@@ -95,6 +98,7 @@ type SpecialProjectRepository interface {
 
 type TxRepository interface {
 	RunToTx(ctx context.Context, fn func(ctx context.Context) error) error
+	BeginTx(ctx context.Context) (*sqlx.Tx, error)
 }
 
 type ResourcePageRepository interface {

--- a/internal/repository/interfaces.go
+++ b/internal/repository/interfaces.go
@@ -98,11 +98,11 @@ type TxRepository interface {
 }
 
 type ResourcePageRepository interface {
+	GetAll(ctx context.Context) ([]models.ResourcePage, error)
 	GetBySlug(ctx context.Context, slug string) (*models.ResourcePage, error)
-	GetBySlugTx(ctx context.Context, queryable Queryable, slug string, lockForUpdate bool) (*models.ResourcePage, error)
-	UpdatePageContentAndLinksTx(ctx context.Context, tx *sqlx.Tx, slug string, title string, content string, links []models.ResourcePageLink) error
-	GetAllSummaries(ctx context.Context) ([]*models.ResourcePage, error)
-	BeginTx(ctx context.Context) (*sqlx.Tx, error)
+	Update(ctx context.Context, slug string, page models.ResourcePage) (*models.ResourcePage, error)
+	Clear(ctx context.Context, slug string) (*models.ResourcePage, error)
+	DeleteLink(ctx context.Context, slug string, id string) (*models.ResourcePage, error)
 }
 
 type Queryable interface {

--- a/internal/repository/postgres/application_repository.go
+++ b/internal/repository/postgres/application_repository.go
@@ -15,7 +15,7 @@ import (
 
 const applicationSelectColumns = `
 	a.id, a.type, a.source, a.status, a.customer_name, a.contact_info,
-	a.project_name, a.box_id, a.special_project_id, a.manager_id,
+	a.project_name, a.box_id, a.special_project_id,
 	NULLIF(TRIM(CONCAT_WS(' ', s.first_name, s.last_name)), '') AS manager_name,
 	a.created_at, a.updated_at`
 
@@ -181,9 +181,6 @@ func buildApplicationWhere(f models.ApplicationFilter) (string, []interface{}) {
 	}
 	if f.Type != nil {
 		add("a.type = $%d", *f.Type)
-	}
-	if f.ManagerID != nil {
-		add("a.manager_id = $%d", *f.ManagerID)
 	}
 	if f.CustomerName != "" {
 		add("a.customer_name ILIKE $%d", "%"+f.CustomerName+"%")

--- a/internal/repository/postgres/special_project.go
+++ b/internal/repository/postgres/special_project.go
@@ -74,7 +74,7 @@ func (r *specialProjectRepo) GetByID(ctx context.Context, id int64) (*models.Spe
 	return &proj, nil
 }
 
-func (r *specialProjectRepo) List(ctx context.Context, statusFilter *bool, searchQuery string, limit, offset int) ([]*models.SpecialProjectDB, int, error) {
+func (r *specialProjectRepo) List(ctx context.Context, statusFilter string, searchQuery string, limit, offset int) ([]*models.SpecialProjectDB, int, error) {
 	// Base query selecting only required fields for the list endpoint
 	baseQuery := listSpecProjectsBaseQuery
 	baseCountQuery := listSpecProjectsCountBaseQuery
@@ -83,11 +83,11 @@ func (r *specialProjectRepo) List(ctx context.Context, statusFilter *bool, searc
 	countArgs := make(map[string]interface{})
 
 	// Apply status filter if provided
-	if statusFilter != nil {
+	if statusFilter != "" {
 		baseQuery += " AND is_active_in_bot = :status"
 		baseCountQuery += " AND is_active_in_bot = :status"
-		args["status"] = *statusFilter
-		countArgs["status"] = *statusFilter
+		args["status"] = statusFilter == "active"
+		countArgs["status"] = statusFilter == "active"
 	}
 
 	// Apply full-text search if query is provided

--- a/internal/repository/postgres/staff_repo.go
+++ b/internal/repository/postgres/staff_repo.go
@@ -17,7 +17,7 @@ import (
 const getUserByEmailQuery = `
     SELECT id, telegram_nick, first_name, last_name, second_name, email,
 		       phone_number, password_hash, role, status, invite_token, department,
-					 position, manager_id, permissions, created_at, updated_at
+					 position, created_at, updated_at
     FROM staff
     WHERE email = $1`
 
@@ -25,18 +25,16 @@ const createUserQuery = `
 	INSERT INTO staff(first_name, last_name, email, invite_token, password_hash)
 	VALUES ($1, $2, $3, $4, $5)
 	RETURNING id, telegram_nick, first_name, email,
-						role, status, permissions,
-						created_at, updated_at
+						role, status, created_at, updated_at
 `
 
 const insertStaffAdminQuery = `
 	INSERT INTO staff (
 		telegram_nick, first_name, last_name, email,
-		password_hash, role, status, invite_token, permissions)
+		password_hash, role, status, invite_token)
 	VALUES ($1, $2, $3, $4, '', $5: :user_role_type, $6: :user_status_type, $7, $8)
 	RETURNING id, telegram_nick, first_name, last_name, second_name, email, phone_number,
-			role, status, invite_token, department, position, manager_id, permissions, 
-					created_at, updated_at`
+			role, status, invite_token, department, position, created_at, updated_at`
 
 const updateStaffQuery = `
 	UPDATE staff SET
@@ -44,19 +42,17 @@ const updateStaffQuery = `
 		email = COALESCE($3, email),
 		role = COALESCE($4: :user_role_type, role),
 		status = COALESCE($5: :user_status_type, status),
-		permissions = COALESCE($6, permissions),
 		telegram_nick = COALESCE($7, telegram_nick),
 	WHERE id = $1
 	RETURNING id, telegram_nick, first_name, last_name, second_name, email,
-			phone_number, role, status, invite_token, department, position, manager_id, permissions,
+			phone_number, role, status, invite_token, department, position, 
 					created_at, updated_at
 `
 const blockStaffQuery = `
 	UPDATE staff SET status = 'blocked': :user_status_type
 	WHERE id = $1
 	RETURNING id, telegram_nick, first_name, last_name, second_name, email,
-			phone_number, role, status, invite_token, department, position, manager_id, permissions,
-					created_at, updated_at
+			phone_number, role, status, invite_token, department, position, created_at, updated_at
 `
 
 type StaffRepo struct {
@@ -117,9 +113,7 @@ func toUser(user *dto.UserRow) *models.UserAPI {
 		Status:       user.Status,
 		Department:   derefString(user.Department),
 		Position:     derefString(user.Position),
-		ManagerID:    derefBigNumbers(user.ManagerID),
 		InviteToken:  derefString(user.InviteToken),
-		Permissions:  user.Permissions,
 		CreatedAt:    user.CreatedAt,
 		UpdatedAt:    user.UpdatedAt,
 	}
@@ -365,7 +359,6 @@ func (u *StaffRepo) CreateStaffByAdmin(ctx context.Context, req *models.StaffAdm
 		req.Role,
 		req.Status,
 		req.InviteToken,
-		pq.Array(req.Permissions),
 	)
 	if err != nil {
 		var pqErr *pq.Error
@@ -388,10 +381,6 @@ func (u *StaffRepo) UpdateStaff(ctx context.Context, id int64, req *models.Staff
 			tg = *req.TelegramNick
 		}
 	}
-	var perms interface{}
-	if req.Permissions != nil {
-		perms = pq.Array(*req.Permissions)
-	}
 
 	err := u.db.GetContext(ctx, &row, updateStaffQuery,
 		id,
@@ -399,7 +388,6 @@ func (u *StaffRepo) UpdateStaff(ctx context.Context, id int64, req *models.Staff
 		req.Email,
 		req.Role,
 		req.Status,
-		perms,
 		tg,
 	)
 	if errors.Is(err, sql.ErrNoRows) {

--- a/internal/repository/postgres/staff_repo.go
+++ b/internal/repository/postgres/staff_repo.go
@@ -29,6 +29,36 @@ const createUserQuery = `
 						created_at, updated_at
 `
 
+const insertStaffAdminQuery = `
+	INSERT INTO staff (
+		telegram_nick, first_name, last_name, email,
+		password_hash, role, status, invite_token, permissions)
+	VALUES ($1, $2, $3, $4, '', $5: :user_role_type, $6: :user_status_type, $7, $8)
+	RETURNING id, telegram_nick, first_name, last_name, second_name, email, phone_number,
+			role, status, invite_token, department, position, manager_id, permissions, 
+					created_at, updated_at`
+
+const updateStaffQuery = `
+	UPDATE staff SET
+		first_name = COALESCE($2, first_name),
+		email = COALESCE($3, email),
+		role = COALESCE($4: :user_role_type, role),
+		status = COALESCE($5: :user_status_type, status),
+		permissions = COALESCE($6, permissions),
+		telegram_nick = COALESCE($7, telegram_nick),
+	WHERE id = $1
+	RETURNING id, telegram_nick, first_name, last_name, second_name, email,
+			phone_number, role, status, invite_token, department, position, manager_id, permissions,
+					created_at, updated_at
+`
+const blockStaffQuery = `
+	UPDATE staff SET status = 'blocked': :user_status_type
+	WHERE id = $1
+	RETURNING id, telegram_nick, first_name, last_name, second_name, email,
+			phone_number, role, status, invite_token, department, position, manager_id, permissions,
+					created_at, updated_at
+`
+
 type StaffRepo struct {
 	db *sqlx.DB
 }
@@ -317,4 +347,78 @@ func (u *StaffRepo) GetByID(ctx context.Context, id int64) (*dto.UserWithDetails
 		VisitHistory:  visitHistory,
 		FavoriteBoxes: favoriteBoxes,
 	}, nil
+}
+
+func (u *StaffRepo) CreateStaffByAdmin(ctx context.Context, req *models.StaffAdminCreate) (*models.UserAPI, error) {
+	var row dto.UserRow
+
+	var tg sql.NullString
+	if req.TelegramNick != nil && *req.TelegramNick != "" {
+		tg = sql.NullString{String: *req.TelegramNick, Valid: true}
+	}
+
+	err := u.db.GetContext(ctx, &row, insertStaffAdminQuery,
+		tg,
+		req.Name,
+		"",
+		req.Email,
+		req.Role,
+		req.Status,
+		req.InviteToken,
+		pq.Array(req.Permissions),
+	)
+	if err != nil {
+		var pqErr *pq.Error
+		if errors.As(err, &pqErr) && pqErr.Code == "23505" {
+			return nil, models.ErrEmailAlreadyExist
+		}
+		return nil, err
+	}
+	return toUser(&row), nil
+}
+
+func (u *StaffRepo) UpdateStaff(ctx context.Context, id int64, req *models.StaffAdminUpdate) (*models.UserAPI, error) {
+	var row dto.UserRow
+
+	var tg interface{}
+	if req.TelegramNick != nil {
+		if *req.TelegramNick == "" {
+			tg = nil
+		} else {
+			tg = *req.TelegramNick
+		}
+	}
+	var perms interface{}
+	if req.Permissions != nil {
+		perms = pq.Array(*req.Permissions)
+	}
+
+	err := u.db.GetContext(ctx, &row, updateStaffQuery,
+		id,
+		req.Name,
+		req.Email,
+		req.Role,
+		req.Status,
+		perms,
+		tg,
+	)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, models.ErrUserNotFound
+	}
+	if err != nil {
+		return nil, err
+	}
+	return toUser(&row), nil
+}
+
+func (u *StaffRepo) BlockStaff(ctx context.Context, id int64) (*models.UserAPI, error) {
+	var row dto.UserRow
+	err := u.db.GetContext(ctx, &row, blockStaffQuery, id)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, models.ErrUserNotFound
+	}
+	if err != nil {
+		return nil, err
+	}
+	return toUser(&row), nil
 }

--- a/internal/repository/postgres/staff_repo.go
+++ b/internal/repository/postgres/staff_repo.go
@@ -16,8 +16,8 @@ import (
 
 const getUserByEmailQuery = `
     SELECT id, telegram_nick, first_name, last_name, second_name, email,
-		       phone_number, password_hash, role, status, invite_token, department,
-					 position, created_at, updated_at
+           phone_number, password_hash, role, status, invite_token, department,
+           position, supervisor, address, created_at, updated_at
     FROM staff
     WHERE email = $1`
 
@@ -29,39 +29,40 @@ const createUserQuery = `
 `
 
 const insertStaffAdminQuery = `
-	INSERT INTO staff (
-    	first_name, last_name, second_name, email,
-    	phone_number, password_hash, role, status,
-    	department, position, invite_token)
-	VALUES ($1, $2, $3, $4, $5, '', $6::user_role_type, $7::user_status_type,
-    	$8, $9, $10)
-	RETURNING id, telegram_nick, first_name, last_name, second_name, email,
-    	phone_number, role, status, invite_token, department, position, created_at, 
-				updated_at`
+    INSERT INTO staff (
+        first_name, last_name, second_name, email,
+        phone_number, password_hash, role, status,
+        department, position, invite_token, supervisor, address)
+    VALUES ($1, $2, $3, $4, $5, '', $6::user_role_type, $7::user_status_type,
+        $8, $9, $10, $11, $12)
+    RETURNING id, telegram_nick, first_name, last_name, second_name, email,
+        phone_number, role, status, invite_token, department, position,
+        supervisor, address, created_at, updated_at`
 
 const updateStaffQuery = `
-	UPDATE staff SET
-    	first_name   = COALESCE($2, first_name),
-    	last_name    = COALESCE($3, last_name),
-    	second_name  = COALESCE($4, second_name),
-    	email        = COALESCE($5, email),
-    	role         = COALESCE($6::user_role_type, role),
-		status       = COALESCE($7::user_status_type, status),
-    	phone_number = COALESCE($8, phone_number),
-    	department   = COALESCE($9, department),
-    	position     = COALESCE($10, position)
-		WHERE id = $1
-	RETURNING id, telegram_nick, first_name, last_name, second_name, email,
-		phone_number, role, status, invite_token, department, position, created_at,
-				updated_at
-`
+    UPDATE staff SET
+        first_name   = COALESCE($2, first_name),
+        last_name    = COALESCE($3, last_name),
+        second_name  = COALESCE($4, second_name),
+        email        = COALESCE($5, email),
+        role         = COALESCE($6::user_role_type, role),
+        status       = COALESCE($7::user_status_type, status),
+        phone_number = COALESCE($8, phone_number),
+        department   = COALESCE($9, department),
+        position     = COALESCE($10, position),
+        supervisor   = COALESCE($11, supervisor),
+        address      = COALESCE($12, address)
+    WHERE id = $1
+    RETURNING id, telegram_nick, first_name, last_name, second_name, email,
+        phone_number, role, status, invite_token, department, position,
+        supervisor, address, created_at, updated_at`
+
 const blockStaffQuery = `
-	UPDATE staff SET status = 'blocked': :user_status_type
-	WHERE id = $1
-	RETURNING id, telegram_nick, first_name, last_name, second_name, email,
-		phone_number, role, status, invite_token, department, position, created_at, 
-				updated_at
-`
+    UPDATE staff SET status = 'blocked'::user_status_type
+    WHERE id = $1
+    RETURNING id, telegram_nick, first_name, last_name, second_name, email,
+        phone_number, role, status, invite_token, department, position,
+        supervisor, address, created_at, updated_at`
 
 type StaffRepo struct {
 	db *sqlx.DB
@@ -122,6 +123,8 @@ func toUser(user *dto.UserRow) *models.UserAPI {
 		Department:   derefString(user.Department),
 		Position:     derefString(user.Position),
 		InviteToken:  derefString(user.InviteToken),
+		Supervisor:   derefString(user.Supervisor),
+		Address:      derefString(user.Address),
 		CreatedAt:    user.CreatedAt,
 		UpdatedAt:    user.UpdatedAt,
 	}
@@ -132,13 +135,6 @@ func derefString(s *string) string {
 		return ""
 	}
 	return *s
-}
-
-func derefBigNumbers(n *int64) int64 {
-	if n == nil {
-		return 0
-	}
-	return *n
 }
 
 func (u *StaffRepo) List(ctx context.Context, role, status, search string, limit, offset int) ([]dto.UserListItem, int, error) {
@@ -220,10 +216,11 @@ func (u *StaffRepo) List(ctx context.Context, role, status, search string, limit
 
 func (u *StaffRepo) GetByID(ctx context.Context, id int64) (*dto.UserWithDetails, error) {
 	userQuery := `
-		SELECT id, telegram_nick, first_name, last_name, second_name, email,
-		       phone_number, role, status, department, position, created_at, updated_at
-		FROM staff
-		WHERE id = $1`
+    SELECT id, telegram_nick, first_name, last_name, second_name, email,
+           phone_number, role, status, department, position,
+           supervisor, address, created_at, updated_at
+    FROM staff
+    WHERE id = $1`
 
 	type userRow struct {
 		ID           int64        `db:"id"`
@@ -237,6 +234,8 @@ func (u *StaffRepo) GetByID(ctx context.Context, id int64) (*dto.UserWithDetails
 		Status       string       `db:"status"`
 		Department   *string      `db:"department"`
 		Position     *string      `db:"position"`
+		Supervisor   *string      `db:"supervisor"`
+		Address      *string      `db:"address"`
 		CreatedAt    sql.NullTime `db:"created_at"`
 		UpdatedAt    sql.NullTime `db:"updated_at"`
 	}
@@ -343,6 +342,8 @@ func (u *StaffRepo) GetByID(ctx context.Context, id int64) (*dto.UserWithDetails
 		Status:        user.Status,
 		Department:    derefString(user.Department),
 		Position:      derefString(user.Position),
+		Supervisor:    derefString(user.Supervisor),
+		Address:       derefString(user.Address),
 		CreatedAt:     user.CreatedAt.Time,
 		UpdatedAt:     user.UpdatedAt.Time,
 		Bookings:      bookings,
@@ -365,6 +366,8 @@ func (u *StaffRepo) CreateStaffByAdmin(ctx context.Context, req *models.StaffAdm
 		req.Department,
 		req.Position,
 		req.InviteToken,
+		req.Supervisor,
+		req.Address,
 	)
 	if err != nil {
 		var pqErr *pq.Error
@@ -390,6 +393,8 @@ func (u *StaffRepo) UpdateStaff(ctx context.Context, id int64, req *models.Staff
 		req.PhoneNumber,
 		req.Department,
 		req.Position,
+		req.Supervisor,
+		req.Address,
 	)
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, models.ErrUserNotFound

--- a/internal/repository/postgres/staff_repo.go
+++ b/internal/repository/postgres/staff_repo.go
@@ -30,29 +30,37 @@ const createUserQuery = `
 
 const insertStaffAdminQuery = `
 	INSERT INTO staff (
-		telegram_nick, first_name, last_name, email,
-		password_hash, role, status, invite_token)
-	VALUES ($1, $2, $3, $4, '', $5: :user_role_type, $6: :user_status_type, $7, $8)
-	RETURNING id, telegram_nick, first_name, last_name, second_name, email, phone_number,
-			role, status, invite_token, department, position, created_at, updated_at`
+    	first_name, last_name, second_name, email,
+    	phone_number, password_hash, role, status,
+    	department, position, invite_token)
+	VALUES ($1, $2, $3, $4, $5, '', $6::user_role_type, $7::user_status_type,
+    	$8, $9, $10)
+	RETURNING id, telegram_nick, first_name, last_name, second_name, email,
+    	phone_number, role, status, invite_token, department, position, created_at, 
+				updated_at`
 
 const updateStaffQuery = `
 	UPDATE staff SET
-		first_name = COALESCE($2, first_name),
-		email = COALESCE($3, email),
-		role = COALESCE($4: :user_role_type, role),
-		status = COALESCE($5: :user_status_type, status),
-		telegram_nick = COALESCE($7, telegram_nick),
-	WHERE id = $1
+    	first_name   = COALESCE($2, first_name),
+    	last_name    = COALESCE($3, last_name),
+    	second_name  = COALESCE($4, second_name),
+    	email        = COALESCE($5, email),
+    	role         = COALESCE($6::user_role_type, role),
+		status       = COALESCE($7::user_status_type, status),
+    	phone_number = COALESCE($8, phone_number),
+    	department   = COALESCE($9, department),
+    	position     = COALESCE($10, position)
+		WHERE id = $1
 	RETURNING id, telegram_nick, first_name, last_name, second_name, email,
-			phone_number, role, status, invite_token, department, position, 
-					created_at, updated_at
+		phone_number, role, status, invite_token, department, position, created_at,
+				updated_at
 `
 const blockStaffQuery = `
 	UPDATE staff SET status = 'blocked': :user_status_type
 	WHERE id = $1
 	RETURNING id, telegram_nick, first_name, last_name, second_name, email,
-			phone_number, role, status, invite_token, department, position, created_at, updated_at
+		phone_number, role, status, invite_token, department, position, created_at, 
+				updated_at
 `
 
 type StaffRepo struct {
@@ -346,18 +354,16 @@ func (u *StaffRepo) GetByID(ctx context.Context, id int64) (*dto.UserWithDetails
 func (u *StaffRepo) CreateStaffByAdmin(ctx context.Context, req *models.StaffAdminCreate) (*models.UserAPI, error) {
 	var row dto.UserRow
 
-	var tg sql.NullString
-	if req.TelegramNick != nil && *req.TelegramNick != "" {
-		tg = sql.NullString{String: *req.TelegramNick, Valid: true}
-	}
-
 	err := u.db.GetContext(ctx, &row, insertStaffAdminQuery,
-		tg,
-		req.Name,
-		"",
+		req.FirstName,
+		req.LastName,
+		req.SecondName,
 		req.Email,
+		req.PhoneNumber,
 		req.Role,
 		req.Status,
+		req.Department,
+		req.Position,
 		req.InviteToken,
 	)
 	if err != nil {
@@ -373,22 +379,17 @@ func (u *StaffRepo) CreateStaffByAdmin(ctx context.Context, req *models.StaffAdm
 func (u *StaffRepo) UpdateStaff(ctx context.Context, id int64, req *models.StaffAdminUpdate) (*models.UserAPI, error) {
 	var row dto.UserRow
 
-	var tg interface{}
-	if req.TelegramNick != nil {
-		if *req.TelegramNick == "" {
-			tg = nil
-		} else {
-			tg = *req.TelegramNick
-		}
-	}
-
 	err := u.db.GetContext(ctx, &row, updateStaffQuery,
 		id,
-		req.Name,
+		req.FirstName,
+		req.LastName,
+		req.SecondName,
 		req.Email,
 		req.Role,
 		req.Status,
-		tg,
+		req.PhoneNumber,
+		req.Department,
+		req.Position,
 	)
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, models.ErrUserNotFound

--- a/internal/service/api/user.go
+++ b/internal/service/api/user.go
@@ -2,6 +2,9 @@ package service
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/hex"
+	repo "github.com/yandex-development-1-team/go/internal/repository/postgres"
 
 	"github.com/yandex-development-1-team/go/internal/dto"
 	"github.com/yandex-development-1-team/go/internal/models"
@@ -33,4 +36,103 @@ func (s *UserService) GetByID(ctx context.Context, id int64) (*dto.UserWithDetai
 	}
 
 	return s.repo.GetByID(ctx, id)
+}
+
+type UsersAdminService struct {
+	staffRepo *repo.StaffRepo
+	rtRepo    *repo.RefreshTokenRepo
+}
+
+func NewUsersAdminService(staffRepo *repo.StaffRepo, rtRepo *repo.RefreshTokenRepo) *UsersAdminService {
+	return &UsersAdminService{staffRepo: staffRepo, rtRepo: rtRepo}
+}
+
+func (s *UsersAdminService) Create(ctx context.Context, req dto.UserCreateRequest) (*models.UserAPI, error) {
+	status := req.Status
+	if status == "" {
+		status = "invited"
+	}
+	perms := req.Permissions
+	if perms == nil {
+		perms = []string{}
+	}
+	if err := validateStaffEnums(req.Role, status); err != nil {
+		return nil, err
+	}
+	m := &models.StaffAdminCreate{
+		Name:         req.Name,
+		Email:        req.Email,
+		Role:         req.Role,
+		Status:       status,
+		Permissions:  perms,
+		TelegramNick: req.TelegramNick,
+		InviteToken:  generateInviteToken(),
+	}
+	return s.staffRepo.CreateStaffByAdmin(ctx, m)
+}
+
+func (s *UsersAdminService) Update(ctx context.Context, id int64, req dto.UserUpdateRequest) (*models.UserAPI, error) {
+	u := &models.StaffAdminUpdate{
+		Name:         req.Name,
+		Email:        req.Email,
+		Role:         req.Role,
+		Status:       req.Status,
+		Permissions:  req.Permissions,
+		TelegramNick: req.TelegramNick,
+	}
+	if u.Role != nil {
+		if err := validateRole(*u.Role); err != nil {
+			return nil, err
+		}
+	}
+	if u.Status != nil {
+		if err := validateStatus(*u.Status); err != nil {
+			return nil, err
+		}
+	}
+	return s.staffRepo.UpdateStaff(ctx, id, u)
+}
+
+func (s *UsersAdminService) Block(ctx context.Context, id int64) (*models.UserAPI, error) {
+	user, err := s.staffRepo.BlockStaff(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	if err := s.rtRepo.DeleteByStaffID(ctx, id); err != nil {
+		return nil, err
+	}
+	return user, nil
+}
+
+func validateStaffEnums(role, status string) error {
+	if err := validateRole(role); err != nil {
+		return err
+	}
+	return validateStatus(status)
+}
+
+func validateRole(role string) error {
+	switch role {
+	case "admin", "manager_1", "manager_2", "manager_3", "user":
+		return nil
+	default:
+		return models.ErrInvalidInput
+	}
+}
+
+func validateStatus(status string) error {
+	switch status {
+	case "active", "blocked", "invited":
+		return nil
+	default:
+		return models.ErrInvalidInput
+	}
+}
+
+func generateInviteToken() string {
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		return ""
+	}
+	return hex.EncodeToString(b)
 }

--- a/internal/service/api/user.go
+++ b/internal/service/api/user.go
@@ -52,10 +52,7 @@ func (s *UsersAdminService) Create(ctx context.Context, req dto.UserCreateReques
 	if status == "" {
 		status = "invited"
 	}
-	perms := req.Permissions
-	if perms == nil {
-		perms = []string{}
-	}
+
 	if err := validateStaffEnums(req.Role, status); err != nil {
 		return nil, err
 	}
@@ -64,7 +61,6 @@ func (s *UsersAdminService) Create(ctx context.Context, req dto.UserCreateReques
 		Email:        req.Email,
 		Role:         req.Role,
 		Status:       status,
-		Permissions:  perms,
 		TelegramNick: req.TelegramNick,
 		InviteToken:  generateInviteToken(),
 	}
@@ -77,7 +73,6 @@ func (s *UsersAdminService) Update(ctx context.Context, id int64, req dto.UserUp
 		Email:        req.Email,
 		Role:         req.Role,
 		Status:       req.Status,
-		Permissions:  req.Permissions,
 		TelegramNick: req.TelegramNick,
 	}
 	if u.Role != nil {

--- a/internal/service/api/user.go
+++ b/internal/service/api/user.go
@@ -57,23 +57,31 @@ func (s *UsersAdminService) Create(ctx context.Context, req dto.UserCreateReques
 		return nil, err
 	}
 	m := &models.StaffAdminCreate{
-		Name:         req.Name,
-		Email:        req.Email,
-		Role:         req.Role,
-		Status:       status,
-		TelegramNick: req.TelegramNick,
-		InviteToken:  generateInviteToken(),
+		FirstName:   req.FirstName,
+		LastName:    req.LastName,
+		SecondName:  derefOrEmpty(req.SecondName),
+		Email:       req.Email,
+		Role:        req.Role,
+		Status:      status,
+		PhoneNumber: req.Phone,
+		Department:  req.Department,
+		Position:    req.Position,
+		InviteToken: generateInviteToken(),
 	}
 	return s.staffRepo.CreateStaffByAdmin(ctx, m)
 }
 
 func (s *UsersAdminService) Update(ctx context.Context, id int64, req dto.UserUpdateRequest) (*models.UserAPI, error) {
 	u := &models.StaffAdminUpdate{
-		Name:         req.Name,
-		Email:        req.Email,
-		Role:         req.Role,
-		Status:       req.Status,
-		TelegramNick: req.TelegramNick,
+		FirstName:   req.FirstName,
+		LastName:    req.LastName,
+		SecondName:  req.SecondName,
+		Email:       req.Email,
+		Role:        req.Role,
+		Status:      req.Status,
+		PhoneNumber: req.Phone,
+		Department:  req.Department,
+		Position:    req.Position,
 	}
 	if u.Role != nil {
 		if err := validateRole(*u.Role); err != nil {
@@ -130,4 +138,11 @@ func generateInviteToken() string {
 		return ""
 	}
 	return hex.EncodeToString(b)
+}
+
+func derefOrEmpty(s *string) string {
+	if s == nil {
+		return ""
+	}
+	return *s
 }

--- a/internal/service/api/user.go
+++ b/internal/service/api/user.go
@@ -66,6 +66,8 @@ func (s *UsersAdminService) Create(ctx context.Context, req dto.UserCreateReques
 		PhoneNumber: req.Phone,
 		Department:  req.Department,
 		Position:    req.Position,
+		Supervisor:  req.Supervisor,
+		Address:     req.Address,
 		InviteToken: generateInviteToken(),
 	}
 	return s.staffRepo.CreateStaffByAdmin(ctx, m)
@@ -82,6 +84,8 @@ func (s *UsersAdminService) Update(ctx context.Context, id int64, req dto.UserUp
 		PhoneNumber: req.Phone,
 		Department:  req.Department,
 		Position:    req.Position,
+		Supervisor:  req.Supervisor,
+		Address:     req.Address,
 	}
 	if u.Role != nil {
 		if err := validateRole(*u.Role); err != nil {

--- a/internal/service/special_project.go
+++ b/internal/service/special_project.go
@@ -71,12 +71,8 @@ func (s *SpecialProjectService) GetByID(ctx context.Context, id int64) (*models.
 }
 
 func (s *SpecialProjectService) List(ctx context.Context, statusStr string, search string, limit, offset int) ([]*models.SpecialProject, int, error) {
-	var statusFilter *bool
-	if statusStr != "" {
-		val := statusStr == "active"
-		statusFilter = &val
-	}
-	dbList, total, err := s.repo.List(ctx, statusFilter, search, limit, offset)
+
+	dbList, total, err := s.repo.List(ctx, statusStr, search, limit, offset)
 	if err != nil {
 		return nil, 0, err
 	}

--- a/internal/service/special_project_test.go
+++ b/internal/service/special_project_test.go
@@ -16,7 +16,7 @@ import (
 type mockSpecialProjectRepo struct {
 	createFn  func(ctx context.Context, proj *models.SpecialProjectDB) (*models.SpecialProjectDB, error)
 	getByIDFn func(ctx context.Context, id int64) (*models.SpecialProjectDB, error)
-	listFn    func(ctx context.Context, statusFilter *bool, searchQuery string, limit, offset int) ([]*models.SpecialProjectDB, int, error)
+	listFn    func(ctx context.Context, statusFilter string, searchQuery string, limit, offset int) ([]*models.SpecialProjectDB, int, error)
 	updateFn  func(ctx context.Context, id int64, update *models.SpecialProjectUpdate) (*models.SpecialProjectDB, error)
 	deleteFn  func(ctx context.Context, id int64) error
 }
@@ -35,7 +35,7 @@ func (m *mockSpecialProjectRepo) GetByID(ctx context.Context, id int64) (*models
 	return nil, nil
 }
 
-func (m *mockSpecialProjectRepo) List(ctx context.Context, statusFilter *bool, searchQuery string, limit, offset int) ([]*models.SpecialProjectDB, int, error) {
+func (m *mockSpecialProjectRepo) List(ctx context.Context, statusFilter string, searchQuery string, limit, offset int) ([]*models.SpecialProjectDB, int, error) {
 	if m.listFn != nil {
 		return m.listFn(ctx, statusFilter, searchQuery, limit, offset)
 	}
@@ -239,7 +239,7 @@ func TestSpecialProjectService_List(t *testing.T) {
 
 	t.Run("success returns list", func(t *testing.T) {
 		repo := &mockSpecialProjectRepo{
-			listFn: func(ctx context.Context, statusFilter *bool, searchQuery string, limit, offset int) ([]*models.SpecialProjectDB, int, error) {
+			listFn: func(ctx context.Context, statusFilter string, searchQuery string, limit, offset int) ([]*models.SpecialProjectDB, int, error) {
 				return []*models.SpecialProjectDB{
 					{ID: 1, Title: "A", IsActiveInBot: true},
 					{ID: 2, Title: "B", IsActiveInBot: false},
@@ -258,7 +258,7 @@ func TestSpecialProjectService_List(t *testing.T) {
 	t.Run("repo error propagated", func(t *testing.T) {
 		repoErr := errors.New("db error")
 		repo := &mockSpecialProjectRepo{
-			listFn: func(ctx context.Context, statusFilter *bool, searchQuery string, limit, offset int) ([]*models.SpecialProjectDB, int, error) {
+			listFn: func(ctx context.Context, statusFilter string, searchQuery string, limit, offset int) ([]*models.SpecialProjectDB, int, error) {
 				return nil, 0, repoErr
 			},
 		}

--- a/migrations/20260420000000_add_supervisor_address_to_staff.sql
+++ b/migrations/20260420000000_add_supervisor_address_to_staff.sql
@@ -1,0 +1,9 @@
+-- +goose Up
+ALTER TABLE staff
+    ADD COLUMN IF NOT EXISTS supervisor VARCHAR(255),
+    ADD COLUMN IF NOT EXISTS address VARCHAR(255);
+
+-- +goose Down
+ALTER TABLE staff
+    DROP COLUMN IF EXISTS supervisor,
+    DROP COLUMN IF EXISTS address;


### PR DESCRIPTION
**cmd/bot/main.go**
Добавлена инициализация usersAdminService
Добавлено поле UsersAdmin в APIServices

**internal/api/handlers/users.go**
Добавлен новый тип UsersHandler с методами Create, Update, Block — для админских операций над сотрудниками.

**internal/api/server/routes.go**
В сигнатуру SetupRoutes добавлен параметр usersHandler *handlers.UsersHandler
Добавлен вызов setupUsersAdminRoutes внутри protected
Добавлена функция setupUsersAdminRoutes — роуты POST /admin/users, PUT /admin/users/:id, PUT /admin/users/:id/block под RequireAdmin

**internal/api/server/server.go**
В APIServices добавлено поле UsersAdmin *apiService.UsersAdminService
В RegisterRoutes добавлена инициализация usersHandler и передача в SetupRoutes

**internal/dto/users.go**
Добавлены три новых типа: UserCreateRequest, UserUpdateRequest, BlockResponse.

**internal/models/models.go**
Добавлены два новых типа в конец файла: StaffAdminCreate, StaffAdminUpdate.

internal/repository/interfaces.go
В интерфейс StaffRepository добавлены три метода: CreateStaffByAdmin, UpdateStaff, BlockStaff.

**internal/repository/postgres/staff_repo.go**
Добавлены SQL-константы insertStaffAdminQuery, updateStaffQuery, blockStaffQuery
Добавлены методы CreateStaffByAdmin, UpdateStaff, BlockStaff на StaffRepo

**internal/service/api/user.go**
Добавлен новый сервис UsersAdminService с методами Create, Update, Block, а также вспомогательные функции validateRole, validateStatus, generateInviteToken.
