### PR TITLE
feat/151: add create, update and block user endpoints

### DIFF
--- a/cmd/bot/main.go
+++ b/cmd/bot/main.go
@@ -124,6 +124,7 @@ func run() error {
 	userService := apiService.NewUserService(staffRepo)
 	applicationSvc := apiService.NewApplicationsService(applicationRepo, txRepo)
 	bookAPISvc := apiService.NewBookingsService(bookRepo, txRepo)
+	usersAdminService := apiService.NewUsersAdminService(staffRepo, refreshTokenRepoRepo)
 
 	metricsMux := http.NewServeMux()
 	metricsMux.Handle("/metrics", metrics.NewHandler())
@@ -154,6 +155,7 @@ func run() error {
 		MiddlewareRepo:    dbSqlx,
 		ApplicationSvc:    applicationSvc,
 		BookingSvc:        bookAPISvc,
+		UsersAdmin:        usersAdminService,
 	}, apiAuthService)
 
 	if cfg.FileGC.Enabled {

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -3525,10 +3525,13 @@
       "UserCreateRequest": {
         "type": "object",
         "properties": {
-          "telegram_nick": {
+          "first_name": {
             "type": "string"
           },
-          "name": {
+          "last_name": {
+            "type": "string"
+          },
+          "second_name": {
             "type": "string"
           },
           "email": {
@@ -3540,35 +3543,58 @@
           "status": {
             "type": "string"
           },
-          "permissions": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
+          "phone_number": {
+            "type": "string"
+          },
+          "department": {
+            "type": "string"
+          },
+          "position": {
+            "type": "string"
+          },
+          "supervisor": {
+            "type": "string"
+          },
+          "address": {
+            "type": "string"
           }
         },
-        "required": [
-          "name",
-          "email",
-          "role"
-        ]
+        "required": ["first_name", "last_name", "email", "role"]
       },
       "UserUpdateRequest": {
         "type": "object",
         "properties": {
-          "telegram_nick": {
+          "first_name": {
             "type": "string"
           },
-          "name": {
+          "last_name": {
+            "type": "string"
+          },
+          "second_name": {
             "type": "string"
           },
           "email": {
-            "type": "string"
+            "type": "string", "format": "email"
           },
           "role": {
-            "type": "string"
+            "type": "string", "enum": ["admin", "manager_1", "manager_2", "manager_3", "user"]
           },
           "status": {
+            "type": "string", "enum": ["active", "blocked", "invited"]
+          },
+          "phone_number": {
+            "type": "string"
+          },
+          "department": {
+            "type": "string"
+          },
+          "position": {
+            "type": "string"
+          },
+          "supervisor": {
+            "type": "string"
+          },
+          "address": {
             "type": "string"
           }
         }

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1515,7 +1515,7 @@
             "in": "query",
             "schema": {
               "type": "integer",
-              "default": 50,
+              "default": 20,
               "minimum": 1,
               "maximum": 100
             }
@@ -3379,8 +3379,9 @@
             "type": "string",
             "format": "uri"
           },
-          "is_active_in_bot": {
-            "type": "boolean"
+          "status": {
+            "type": "string",
+            "enum": ["active", "inactive"]
           },
           "created_at": {
             "type": "string",
@@ -3402,8 +3403,9 @@
           "title": {
             "type": "string"
           },
-          "is_active_in_bot": {
-            "type": "boolean"
+          "status": {
+            "type": "string",
+            "enum": ["active", "inactive"]
           }
         }
       },
@@ -3420,9 +3422,10 @@
             "type": "string",
             "format": "uri"
           },
-          "is_active_in_bot": {
-            "type": "boolean",
-            "default": false
+          "status": {
+            "type": "string",
+            "enum": ["active", "inactive"],
+            "default": "active"
           }
         },
         "required": [
@@ -3442,8 +3445,9 @@
             "type": "string",
             "format": "uri"
           },
-          "is_active_in_bot": {
-            "type": "boolean"
+          "status": {
+            "type": "string",
+            "enum": ["active", "inactive"]
           }
         }
       },

--- a/internal/api/handlers/auth.go
+++ b/internal/api/handlers/auth.go
@@ -36,7 +36,7 @@ func (h *AuthHandler) HandleLogin(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, dto.LoginResponse{
-		AccessToken:  authResult.Token,
+		Token:        authResult.Token,
 		RefreshToken: authResult.RefreshToken,
 		User:         toUserResponse(authResult.User),
 	})
@@ -59,7 +59,7 @@ func (h *AuthHandler) HandleRefresh(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, dto.RefreshResponse{
-		AccessToken:  tokenResponse.Token,
+		Token:        tokenResponse.Token,
 		RefreshToken: tokenResponse.RefreshToken,
 	})
 }
@@ -83,7 +83,7 @@ func (h *AuthHandler) RegisterHandler(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusCreated, dto.LoginResponse{
-		AccessToken:  authResult.Token,
+		Token:        authResult.Token,
 		RefreshToken: authResult.RefreshToken,
 		User:         toUserResponse(authResult.User),
 	})
@@ -162,6 +162,7 @@ func toUserResponse(user *models.UserAPI) dto.UserResponse {
 		Position:     user.Position,
 		Supervisor:   user.Supervisor,
 		Address:      user.Address,
+		Image:        user.Image,
 		InviteToken:  user.InviteToken,
 		CreatedAt:    user.CreatedAt,
 		UpdatedAt:    user.UpdatedAt,

--- a/internal/api/handlers/auth.go
+++ b/internal/api/handlers/auth.go
@@ -36,7 +36,7 @@ func (h *AuthHandler) HandleLogin(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, dto.LoginResponse{
-		Token:        authResult.Token,
+		AccessToken:  authResult.Token,
 		RefreshToken: authResult.RefreshToken,
 		User:         toUserResponse(authResult.User),
 	})
@@ -59,7 +59,7 @@ func (h *AuthHandler) HandleRefresh(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, dto.RefreshResponse{
-		Token:        tokenResponse.Token,
+		AccessToken:  tokenResponse.Token,
 		RefreshToken: tokenResponse.RefreshToken,
 	})
 }
@@ -83,7 +83,7 @@ func (h *AuthHandler) RegisterHandler(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusCreated, dto.LoginResponse{
-		Token:        authResult.Token,
+		AccessToken:  authResult.Token,
 		RefreshToken: authResult.RefreshToken,
 		User:         toUserResponse(authResult.User),
 	})
@@ -160,6 +160,8 @@ func toUserResponse(user *models.UserAPI) dto.UserResponse {
 		Status:       user.Status,
 		Department:   user.Department,
 		Position:     user.Position,
+		Supervisor:   user.Supervisor,
+		Address:      user.Address,
 		InviteToken:  user.InviteToken,
 		CreatedAt:    user.CreatedAt,
 		UpdatedAt:    user.UpdatedAt,

--- a/internal/api/handlers/boxes.go
+++ b/internal/api/handlers/boxes.go
@@ -141,6 +141,46 @@ func (h *BoxHandler) Delete(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{"message": "Коробочное решение успешно удалено"})
 }
 
+func (h *BoxHandler) UploadImage(c *gin.Context) {
+	idStr := c.Param("id")
+	id, err := strconv.ParseInt(idStr, 10, 64)
+	if err != nil {
+		apierrors.WriteErrorMessagesGin(c, http.StatusBadRequest, []string{"Некорректный идентификатор"})
+		return
+	}
+	formFile, err := c.FormFile("image")
+	if err != nil {
+		apierrors.WriteErrorMessagesGin(c, http.StatusBadRequest, []string{"Файл image обязателен"})
+		return
+	}
+	src, err := formFile.Open()
+	if err != nil {
+		apierrors.WriteErrorMessagesGin(c, http.StatusBadRequest, []string{"Не удалось открыть загруженный файл"})
+		return
+	}
+	defer func() { _ = src.Close() }()
+
+	contentType := formFile.Header.Get("Content-Type")
+	if contentType == "" {
+		contentType = "application/octet-stream"
+	}
+
+	imageURL, err := h.boxService.UploadImage(
+		c.Request.Context(),
+		id,
+		src,
+		formFile.Filename,
+		contentType,
+		formFile.Size,
+	)
+	if err != nil {
+		apierrors.WriteErrorGin(c, err)
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"image_url": imageURL})
+}
+
 func (h *BoxHandler) UpdateStatus(c *gin.Context) {
 	idStr := c.Param("id")
 	id, err := strconv.ParseInt(idStr, 10, 64)

--- a/internal/api/handlers/special_project.go
+++ b/internal/api/handlers/special_project.go
@@ -87,23 +87,14 @@ func (h *SpecialProjectHandler) ListSpecialProjects(c *gin.Context) {
 		return
 	}
 
-	limitP := c.Query("limit")
-	limit, err := strconv.Atoi(limitP)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_limit"})
-		return
+	limit, err := strconv.Atoi(c.DefaultQuery("limit", "20"))
+	if err != nil || limit < 0 {
+		limit = 20
 	}
 
-	offsetP := c.Query("offset")
-	offset, err := strconv.Atoi(offsetP)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_limit"})
-		return
-	}
-
-	if limit < 0 || offset < 0 {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid_status"})
-		return
+	offset, err := strconv.Atoi(c.DefaultQuery("offset", "0"))
+	if err != nil || offset < 0 {
+		offset = 0
 	}
 
 	domainlist, total, err := h.svc.List(c.Request.Context(), status, search, limit, offset)

--- a/internal/api/handlers/users.go
+++ b/internal/api/handlers/users.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"errors"
 	"net/http"
 	"strconv"
 
@@ -11,6 +12,65 @@ import (
 	"github.com/yandex-development-1-team/go/internal/models"
 	apiService "github.com/yandex-development-1-team/go/internal/service/api"
 )
+
+type UsersHandler struct {
+	svc *apiService.UsersAdminService
+}
+
+func NewUsersHandler(svc *apiService.UsersAdminService) *UsersHandler {
+	return &UsersHandler{svc: svc}
+}
+
+func (h *UsersHandler) Create(c *gin.Context) {
+	var req dto.UserCreateRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		apierrors.WriteErrorMessagesGin(c, http.StatusBadRequest, []string{"Некорректные данные"})
+		return
+	}
+	user, err := h.svc.Create(c.Request.Context(), req)
+	if err != nil {
+		apierrors.WriteErrorGin(c, err)
+		return
+	}
+	c.JSON(http.StatusCreated, toUserResponse(user))
+}
+
+func (h *UsersHandler) Update(c *gin.Context) {
+	id, err := strconv.ParseInt(c.Param("id"), 10, 64)
+	if err != nil || id <= 0 {
+		apierrors.WriteErrorMessagesGin(c, http.StatusBadRequest, []string{"Некорректный id"})
+		return
+	}
+	var req dto.UserUpdateRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		apierrors.WriteErrorMessagesGin(c, http.StatusBadRequest, []string{"Некорректные данные"})
+		return
+	}
+	user, err := h.svc.Update(c.Request.Context(), id, req)
+	if err != nil {
+		apierrors.WriteErrorGin(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, toUserResponse(user))
+}
+
+func (h *UsersHandler) Block(c *gin.Context) {
+	id, err := strconv.ParseInt(c.Param("id"), 10, 64)
+	if err != nil || id <= 0 {
+		apierrors.WriteErrorMessagesGin(c, http.StatusBadRequest, []string{"Некорректный id"})
+		return
+	}
+	user, err := h.svc.Block(c.Request.Context(), id)
+	if err != nil {
+		apierrors.WriteErrorGin(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, dto.BlockResponse{
+		ID:        user.ID,
+		Status:    "blocked",
+		UpdatedAt: user.UpdatedAt,
+	})
+}
 
 type UserHandler struct {
 	svc *apiService.UserService
@@ -60,7 +120,7 @@ func (h *UserHandler) GetByID(c *gin.Context) {
 
 	user, err := h.svc.GetByID(c.Request.Context(), id)
 	if err != nil {
-		if err == models.ErrUserNotFound {
+		if errors.Is(err, models.ErrUserNotFound) {
 			apierrors.WriteErrorMessagesGin(c, http.StatusNotFound, []string{"Пользователь не найден"})
 			return
 		}

--- a/internal/api/handlers/users_test.go
+++ b/internal/api/handlers/users_test.go
@@ -1,0 +1,417 @@
+//go:build integration
+
+package handlers
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/bcrypt"
+
+	pgrepo "github.com/yandex-development-1-team/go/internal/repository/postgres"
+	svcapi "github.com/yandex-development-1-team/go/internal/service/api"
+)
+
+func generateAdminToken(t *testing.T) string {
+	t.Helper()
+	claims := svcapi.AccessClaims{
+		UserID: 1,
+		Role:   "admin",
+		RegisteredClaims: jwt.RegisteredClaims{
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour)),
+		},
+	}
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	signed, err := token.SignedString([]byte("test-secret"))
+	require.NoError(t, err)
+	return signed
+}
+
+func setupUsersAdminServer(t *testing.T) *httptest.Server {
+	t.Helper()
+
+	staffRepo := pgrepo.NewStaffRepo(db)
+	refreshRepo := pgrepo.NewRefreshTokenRepo(db)
+	svc := svcapi.NewUsersAdminService(staffRepo, refreshRepo)
+	handler := NewUsersHandler(svc)
+
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+
+	router.Use(func(c *gin.Context) {
+		authHeader := c.GetHeader("Authorization")
+		if authHeader == "" {
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"errors": []string{"unauthorized"}})
+			return
+		}
+		tokenStr := authHeader[len("Bearer "):]
+		claims := &svcapi.AccessClaims{}
+		_, err := jwt.ParseWithClaims(tokenStr, claims, func(token *jwt.Token) (interface{}, error) {
+			return []byte("test-secret"), nil
+		})
+		if err != nil {
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"errors": []string{"unauthorized"}})
+			return
+		}
+		c.Set("user_id", claims.UserID)
+		c.Set("role", claims.Role)
+		c.Next()
+	})
+
+	users := router.Group("/users")
+	users.Use(func(c *gin.Context) {
+		role, _ := c.Get("role")
+		if role != "admin" {
+			c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"errors": []string{"forbidden"}})
+			return
+		}
+		c.Next()
+	})
+	{
+		users.POST("", handler.Create)
+		users.PUT("/:id", handler.Update)
+		users.PUT("/:id/block", handler.Block)
+	}
+
+	server := httptest.NewServer(router)
+	t.Cleanup(server.Close)
+	return server
+}
+
+func authHeader(token string) string {
+	return "Bearer " + token
+}
+
+func ptr(s string) *string { return &s }
+
+func TestUsersAdmin_Create_Success(t *testing.T) {
+	_, _ = db.Exec(`TRUNCATE TABLE staff CASCADE`)
+	server := setupUsersAdminServer(t)
+	token := generateAdminToken(t)
+
+	body := map[string]interface{}{
+		"first_name": "Иван",
+		"last_name":  "Иванов",
+		"email":      "ivan@example.com",
+		"role":       "manager_1",
+	}
+	b, _ := json.Marshal(body)
+
+	resp, err := doRequest(server.URL+"/users", http.MethodPost, b, authHeader(token))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusCreated, resp.StatusCode)
+
+	var result map[string]any
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&result))
+	assert.Equal(t, "ivan@example.com", result["email"])
+	assert.Equal(t, "manager_1", result["role"])
+	assert.Equal(t, "invited", result["status"])
+}
+
+func TestUsersAdmin_Create_AllFields(t *testing.T) {
+	_, _ = db.Exec(`TRUNCATE TABLE staff CASCADE`)
+	server := setupUsersAdminServer(t)
+	token := generateAdminToken(t)
+
+	body := map[string]interface{}{
+		"first_name":  "Мария",
+		"last_name":   "Петрова",
+		"second_name": "Сергеевна",
+		"email":       "maria@example.com",
+		"role":        "manager_2",
+		"department":  "Маркетинг",
+		"position":    "Менеджер",
+		"supervisor":  "Иван Иванов",
+		"address":     "Москва",
+	}
+	b, _ := json.Marshal(body)
+
+	resp, err := doRequest(server.URL+"/users", http.MethodPost, b, authHeader(token))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusCreated, resp.StatusCode)
+
+	var result map[string]any
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&result))
+	assert.Equal(t, "maria@example.com", result["email"])
+	assert.Equal(t, "manager_2", result["role"])
+}
+
+func TestUsersAdmin_Create_DuplicateEmail(t *testing.T) {
+	_, _ = db.Exec(`TRUNCATE TABLE staff CASCADE`)
+	server := setupUsersAdminServer(t)
+	token := generateAdminToken(t)
+
+	body := map[string]interface{}{
+		"first_name": "Иван",
+		"last_name":  "Иванов",
+		"email":      "dup@example.com",
+		"role":       "manager_1",
+	}
+	b, _ := json.Marshal(body)
+
+	resp1, _ := doRequest(server.URL+"/users", http.MethodPost, b, authHeader(token))
+	resp1.Body.Close()
+
+	resp2, err := doRequest(server.URL+"/users", http.MethodPost, b, authHeader(token))
+	require.NoError(t, err)
+	defer resp2.Body.Close()
+	assert.Equal(t, http.StatusConflict, resp2.StatusCode)
+}
+
+func TestUsersAdmin_Create_InvalidRole(t *testing.T) {
+	_, _ = db.Exec(`TRUNCATE TABLE staff CASCADE`)
+	server := setupUsersAdminServer(t)
+	token := generateAdminToken(t)
+
+	body := map[string]interface{}{
+		"first_name": "Иван",
+		"last_name":  "Иванов",
+		"email":      "role@example.com",
+		"role":       "superadmin",
+	}
+	b, _ := json.Marshal(body)
+
+	resp, err := doRequest(server.URL+"/users", http.MethodPost, b, authHeader(token))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+}
+
+func TestUsersAdmin_Create_MissingRequiredFields(t *testing.T) {
+	_, _ = db.Exec(`TRUNCATE TABLE staff CASCADE`)
+	server := setupUsersAdminServer(t)
+	token := generateAdminToken(t)
+
+	body := map[string]interface{}{
+		"first_name": "Иван",
+		"last_name":  "Иванов",
+		"role":       "manager_1",
+	}
+	b, _ := json.Marshal(body)
+
+	resp, err := doRequest(server.URL+"/users", http.MethodPost, b, authHeader(token))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+}
+
+func TestUsersAdmin_Create_Unauthorized(t *testing.T) {
+	server := setupUsersAdminServer(t)
+
+	body := map[string]interface{}{
+		"first_name": "Иван",
+		"last_name":  "Иванов",
+		"email":      "unauth@example.com",
+		"role":       "manager_1",
+	}
+	b, _ := json.Marshal(body)
+
+	resp, err := doRequest(server.URL+"/users", http.MethodPost, b, "")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+}
+
+func TestUsersAdmin_Update_Success(t *testing.T) {
+	_, _ = db.Exec(`TRUNCATE TABLE staff CASCADE`)
+	server := setupUsersAdminServer(t)
+	token := generateAdminToken(t)
+
+	id := seedStaffAdmin(t, "update@example.com")
+
+	body := map[string]interface{}{
+		"first_name": "Обновлённое",
+		"department": "IT",
+		"position":   "Senior",
+		"supervisor": "Начальник",
+		"address":    "Санкт-Петербург",
+	}
+	b, _ := json.Marshal(body)
+
+	resp, err := doRequest(fmt.Sprintf("%s/users/%d", server.URL, id), http.MethodPut, b, authHeader(token))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var result map[string]any
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&result))
+	assert.Equal(t, "Обновлённое", result["name"])
+}
+
+func TestUsersAdmin_Update_NotFound(t *testing.T) {
+	_, _ = db.Exec(`TRUNCATE TABLE staff CASCADE`)
+	server := setupUsersAdminServer(t)
+	token := generateAdminToken(t)
+
+	body := map[string]interface{}{"first_name": "Тест"}
+	b, _ := json.Marshal(body)
+
+	resp, err := doRequest(server.URL+"/users/99999", http.MethodPut, b, authHeader(token))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+}
+
+func TestUsersAdmin_Update_InvalidID(t *testing.T) {
+	server := setupUsersAdminServer(t)
+	token := generateAdminToken(t)
+
+	body := map[string]interface{}{"first_name": "Тест"}
+	b, _ := json.Marshal(body)
+
+	resp, err := doRequest(server.URL+"/users/abc", http.MethodPut, b, authHeader(token))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+}
+
+func TestUsersAdmin_Update_InvalidRole(t *testing.T) {
+	_, _ = db.Exec(`TRUNCATE TABLE staff CASCADE`)
+	server := setupUsersAdminServer(t)
+	token := generateAdminToken(t)
+
+	id := seedStaffAdmin(t, "role_upd@example.com")
+
+	role := "superadmin"
+	body := map[string]interface{}{"role": role}
+	b, _ := json.Marshal(body)
+
+	resp, err := doRequest(fmt.Sprintf("%s/users/%d", server.URL, id), http.MethodPut, b, authHeader(token))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+}
+
+func TestUsersAdmin_Block_Success(t *testing.T) {
+	_, _ = db.Exec(`TRUNCATE TABLE staff CASCADE`)
+	server := setupUsersAdminServer(t)
+	token := generateAdminToken(t)
+
+	id := seedStaffAdmin(t, "block@example.com")
+
+	resp, err := doRequest(fmt.Sprintf("%s/users/%d/block", server.URL, id), http.MethodPut, nil, authHeader(token))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var result map[string]any
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&result))
+	assert.Equal(t, "blocked", result["status"])
+	assert.Equal(t, float64(id), result["id"])
+}
+
+func TestUsersAdmin_Block_UserCannotLoginAfterBlock(t *testing.T) {
+	_, _ = db.Exec(`TRUNCATE TABLE staff CASCADE`)
+	server := setupUsersAdminServer(t)
+	token := generateAdminToken(t)
+
+	hash, _ := bcrypt.GenerateFromPassword([]byte("password123"), bcrypt.MinCost)
+	var id int64
+	err := db.QueryRow(`
+		INSERT INTO staff (first_name, last_name, email, password_hash, role, status)
+		VALUES ('Тест', 'Блок', 'loginblock@example.com', $1, 'manager_1', 'active')
+		RETURNING id`, string(hash)).Scan(&id)
+	require.NoError(t, err)
+
+	resp, err := doRequest(fmt.Sprintf("%s/users/%d/block", server.URL, id), http.MethodPut, nil, authHeader(token))
+	require.NoError(t, err)
+	resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var status string
+	err = db.QueryRow(`SELECT status FROM staff WHERE id = $1`, id).Scan(&status)
+	require.NoError(t, err)
+	assert.Equal(t, "blocked", status)
+}
+
+func TestUsersAdmin_Block_RefreshTokensRevoked(t *testing.T) {
+	_, _ = db.Exec(`TRUNCATE TABLE staff CASCADE`)
+	_, _ = db.Exec(`TRUNCATE TABLE refresh_tokens CASCADE`)
+	server := setupUsersAdminServer(t)
+	token := generateAdminToken(t)
+
+	id := seedStaffAdmin(t, "revoke@example.com")
+
+	_, err := db.Exec(`
+    	INSERT INTO refresh_tokens (user_id, token, expires_at)
+    	VALUES ($1, 'test-refresh-token', NOW() + INTERVAL '7 days')`, id)
+	require.NoError(t, err)
+
+	var count int
+	_ = db.QueryRow(`SELECT COUNT(*) FROM refresh_tokens WHERE user_id = $1`, id).Scan(&count)
+	assert.Equal(t, 1, count)
+
+	resp, err := doRequest(fmt.Sprintf("%s/users/%d/block", server.URL, id), http.MethodPut, nil, authHeader(token))
+	require.NoError(t, err)
+	resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	_ = db.QueryRow(`SELECT COUNT(*) FROM refresh_tokens WHERE user_id = $1`, id).Scan(&count)
+	assert.Equal(t, 0, count)
+}
+
+func TestUsersAdmin_Block_NotFound(t *testing.T) {
+	_, _ = db.Exec(`TRUNCATE TABLE staff CASCADE`)
+	server := setupUsersAdminServer(t)
+	token := generateAdminToken(t)
+
+	resp, err := doRequest(server.URL+"/users/99999/block", http.MethodPut, nil, authHeader(token))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+}
+
+func TestUsersAdmin_Block_InvalidID(t *testing.T) {
+	server := setupUsersAdminServer(t)
+	token := generateAdminToken(t)
+
+	resp, err := doRequest(server.URL+"/users/abc/block", http.MethodPut, nil, authHeader(token))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+}
+
+func seedStaffAdmin(t *testing.T, email string) int64 {
+	t.Helper()
+	var id int64
+	err := db.QueryRow(`
+		INSERT INTO staff (first_name, last_name, email, role, status)
+		VALUES ('Тест', 'Тестов', $1, 'manager_1', 'active')
+		RETURNING id`, email).Scan(&id)
+	require.NoError(t, err)
+	return id
+}
+
+func doRequest(url, method string, body []byte, auth string) (*http.Response, error) {
+	var req *http.Request
+	var err error
+
+	if body != nil {
+		req, err = http.NewRequest(method, url, bytes.NewReader(body))
+	} else {
+		req, err = http.NewRequest(method, url, nil)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	if auth != "" {
+		req.Header.Set("Authorization", auth)
+	}
+
+	return http.DefaultClient.Do(req)
+}

--- a/internal/api/server/routes.go
+++ b/internal/api/server/routes.go
@@ -9,7 +9,7 @@ import (
 	"github.com/yandex-development-1-team/go/internal/models"
 )
 
-func SetupRoutes(client *sqlx.DB, router *gin.Engine, jwtSecret []byte, authHandler *handlers.AuthHandler, boxHandler *handlers.BoxHandler, specProjHandler *handlers.SpecialProjectHandler, settingsHandler *handlers.SettingsHandler, analyticsHandler *handlers.AnalyticsHandler, recPageHandler *handlers.ResourcePageHandler, userHandler *handlers.UserHandler, fileHandler *handlers.FileHandler, applicationHandler *handlers.ApplicationHandler, bookingHandler *handlers.BookingHandler) {
+func SetupRoutes(client *sqlx.DB, router *gin.Engine, jwtSecret []byte, authHandler *handlers.AuthHandler, boxHandler *handlers.BoxHandler, specProjHandler *handlers.SpecialProjectHandler, settingsHandler *handlers.SettingsHandler, analyticsHandler *handlers.AnalyticsHandler, recPageHandler *handlers.ResourcePageHandler, userHandler *handlers.UserHandler, fileHandler *handlers.FileHandler, applicationHandler *handlers.ApplicationHandler, usersHandler *handlers.UsersHandler, bookingHandler *handlers.BookingHandler) {
 	middlewareRepo := middleware.NewMiddlewareRepository(client)
 	apiV1 := router.Group("/api/v1")
 	{
@@ -25,6 +25,7 @@ func SetupRoutes(client *sqlx.DB, router *gin.Engine, jwtSecret []byte, authHand
 			setupUserRoutes(protected, userHandler)
 			setupResourcesRoutes(protected, recPageHandler)
 			setupFileRoutes(protected, fileHandler)
+			setupUsersAdminRoutes(protected, usersHandler)
 			setupApplicationRoutes(protected, applicationHandler, middlewareRepo)
 			setupBookingRoutes(protected, bookingHandler, middlewareRepo)
 			setupDashboardRoutes(protected, userHandler)
@@ -73,6 +74,7 @@ func setupBoxRoutes(rg *gin.RouterGroup, boxHandler *handlers.BoxHandler, middle
 		boxes.GET("/:id", middleware.RequireManagersOrAdmin(), boxHandler.GetByID)
 		boxes.PUT("/:id", middlewareRepo.RoleVerification(models.PermBoxesEdit), boxHandler.Update)
 		boxes.DELETE("/:id", middlewareRepo.RoleVerification(models.PermBoxesDelete), boxHandler.Delete)
+		boxes.POST("/:id/image", middlewareRepo.RoleVerification(models.PermBoxesEdit), boxHandler.UploadImage)
 		boxes.PUT("/:id/status", middlewareRepo.RoleVerification(models.PermBoxesEdit), boxHandler.UpdateStatus)
 	}
 }
@@ -133,6 +135,16 @@ func setupBookingRoutes(rg *gin.RouterGroup, h *handlers.BookingHandler, middlew
 		bookings.GET("/:id", middlewareRepo.RoleVerification(models.PermBookingsView), h.BookingsById)
 		bookings.PUT("/:id/status", middlewareRepo.RoleVerification(models.PermBookingsEdit), h.UpdateBookingStatus)
 		bookings.DELETE("/:id", middlewareRepo.RoleVerification(models.PermBookingsDelete), h.DeleteBooking)
+	}
+}
+
+func setupUsersAdminRoutes(rg *gin.RouterGroup, h *handlers.UsersHandler) {
+	users := rg.Group("/users")
+	users.Use(middleware.RequireAdmin())
+	{
+		users.POST("", h.Create)
+		users.PUT("/:id", h.Update)
+		users.PUT("/:id/block", h.Block)
 	}
 }
 

--- a/internal/api/server/server.go
+++ b/internal/api/server/server.go
@@ -25,6 +25,7 @@ type APIServices struct {
 	RecPageSvc        *service.ResourcePageService
 	UserSvc           *apiService.UserService
 	FileService       *apiService.FileService
+	UsersAdmin        *apiService.UsersAdminService
 	ApplicationRepo   repository.ApplicationRepository
 	MiddlewareRepo    *sqlx.DB
 	ApplicationSvc    *apiService.ApplicationsService
@@ -67,10 +68,11 @@ func (s *Server) RegisterRoutes(yandexFormToken string) {
 	recPageHandler := handlers.NewResourcePageHandler(s.services.RecPageSvc)
 	userHandler := handlers.NewUserHandler(s.services.UserSvc)
 	fileHandler := handlers.NewFileHandler(s.services.FileService)
+	usersHandler := handlers.NewUsersHandler(s.services.UsersAdmin)
 	applicationHandler := handlers.NewApplicationHandler(s.services.ApplicationSvc, yandexFormToken)
 	bookingHamdler := handlers.NewBookingHandler(s.services.BookingSvc)
 
-	SetupRoutes(s.services.MiddlewareRepo, s.router, s.authService.JwtSecret, authHandler, boxHandler, specProjHandler, settingsHandler, analyticsHandler, recPageHandler, userHandler, fileHandler, applicationHandler, bookingHamdler)
+	SetupRoutes(s.services.MiddlewareRepo, s.router, s.authService.JwtSecret, authHandler, boxHandler, specProjHandler, settingsHandler, analyticsHandler, recPageHandler, userHandler, fileHandler, applicationHandler, usersHandler, bookingHamdler)
 }
 
 func (s *Server) Run(cfg *config.Config) error {

--- a/internal/dto/auth.go
+++ b/internal/dto/auth.go
@@ -10,7 +10,7 @@ type LoginRequest struct {
 }
 
 type LoginResponse struct {
-	AccessToken  string       `json:"token"`
+	Token        string       `json:"token"`
 	RefreshToken string       `json:"refresh_token"`
 	User         UserResponse `json:"user"`
 }
@@ -29,6 +29,7 @@ type UserResponse struct {
 	Position     string    `json:"position"`
 	Supervisor   string    `json:"supervisor"`
 	Address      string    `json:"address"`
+	Image        string    `json:"image"`
 	InviteToken  string    `json:"invite_token"`
 	CreatedAt    time.Time `json:"created_at"`
 	UpdatedAt    time.Time `json:"updated_at"`
@@ -60,7 +61,7 @@ type RefreshRequest struct {
 }
 
 type RefreshResponse struct {
-	AccessToken  string `json:"token"`
+	Token        string `json:"token"`
 	RefreshToken string `json:"refresh_token"`
 }
 

--- a/internal/dto/auth.go
+++ b/internal/dto/auth.go
@@ -10,7 +10,7 @@ type LoginRequest struct {
 }
 
 type LoginResponse struct {
-	Token        string       `json:"token"`
+	AccessToken  string       `json:"token"`
 	RefreshToken string       `json:"refresh_token"`
 	User         UserResponse `json:"user"`
 }
@@ -27,6 +27,8 @@ type UserResponse struct {
 	Status       string    `json:"status"`
 	Department   string    `json:"department"`
 	Position     string    `json:"position"`
+	Supervisor   string    `json:"supervisor"`
+	Address      string    `json:"address"`
 	InviteToken  string    `json:"invite_token"`
 	CreatedAt    time.Time `json:"created_at"`
 	UpdatedAt    time.Time `json:"updated_at"`
@@ -46,6 +48,9 @@ type UserRow struct {
 	InviteToken  *string   `db:"invite_token"`
 	Department   *string   `db:"department"`
 	Position     *string   `db:"position"`
+	Image        *string   `db:"image"`
+	Supervisor   *string   `db:"supervisor"`
+	Address      *string   `db:"address"`
 	CreatedAt    time.Time `db:"created_at"`
 	UpdatedAt    time.Time `db:"updated_at"`
 }
@@ -55,7 +60,7 @@ type RefreshRequest struct {
 }
 
 type RefreshResponse struct {
-	Token        string `json:"token"`
+	AccessToken  string `json:"token"`
 	RefreshToken string `json:"refresh_token"`
 }
 

--- a/internal/dto/users.go
+++ b/internal/dto/users.go
@@ -2,12 +2,53 @@ package dto
 
 import "time"
 
+type UserCreateRequest struct {
+	FirstName   string  `json:"first_name"`
+	LastName    string  `json:"last_name"`
+	Email       string  `json:"email" binding:"required,email"`
+	Role        string  `json:"role" binding:"required"`
+	Status      string  `json:"status,omitempty"`
+	PhoneNumber *string `json:"phone_number,omitempty"`
+	Image       *string `json:"image,omitempty"`
+	Department  *string `json:"department,omitempty"`
+	Position    *string `json:"position,omitempty"`
+	Supervisor  *string `json:"supervisor,omitempty"`
+	Address     *string `json:"address,omitempty"`
+	SecondName  *string `json:"second_name,omitempty"`
+}
+
+type UserUpdateRequest struct {
+	FirstName   *string `json:"first_name,omitempty"`
+	LastName    *string `json:"last_name,omitempty"`
+	Email       *string `json:"email,omitempty"`
+	Role        *string `json:"role,omitempty"`
+	Status      *string `json:"status,omitempty"`
+	PhoneNumber *string `json:"phone_number,omitempty"`
+	Image       *string `json:"image,omitempty"`
+	Department  *string `json:"department,omitempty"`
+	Position    *string `json:"position,omitempty"`
+	Supervisor  *string `json:"supervisor,omitempty"`
+	Address     *string `json:"address,omitempty"`
+	SecondName  *string `json:"second_name,omitempty"`
+}
+
+type BlockResponse struct {
+	ID        int64     `json:"id"`
+	Status    string    `json:"status"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
 type UserListItem struct {
 	ID           int64     `json:"id"`
 	TelegramNick string    `json:"telegram_nick"`
 	Name         string    `json:"name"`
 	Role         string    `json:"role"`
 	Status       string    `json:"status"`
+	Department   string    `json:"department"`
+	Supervisor   string    `json:"supervisor"`
+	Position     string    `json:"position"`
+	PhoneNumber  string    `json:"phone_number"`
+	Email        string    `json:"email"`
 	CreatedAt    time.Time `json:"created_at"`
 }
 
@@ -41,11 +82,14 @@ type UserWithDetails struct {
 	Status        string             `json:"status"`
 	Department    string             `json:"department"`
 	Position      string             `json:"position"`
+	Supervisor    string             `json:"supervisor"`
+	Address       string             `json:"address"`
 	CreatedAt     time.Time          `json:"created_at"`
 	UpdatedAt     time.Time          `json:"updated_at"`
 	Bookings      []UserBookingItem  `json:"bookings"`
 	VisitHistory  []VisitHistoryItem `json:"visit_history"`
 	FavoriteBoxes []int64            `json:"favorite_boxes"`
+	Image         string             `json:"image"`
 }
 
 type DashboardOverview struct {

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -120,8 +120,11 @@ type UserAPI struct {
 	PhoneNumber  string
 	Role         string
 	Status       string
+	Image        string
 	Department   string
 	Position     string
+	Supervisor   string
+	Address      string
 	InviteToken  string
 	CreatedAt    time.Time
 	UpdatedAt    time.Time
@@ -169,4 +172,35 @@ type UserSession struct {
 type RefreshResponse struct {
 	Token        string
 	RefreshToken string
+}
+
+type StaffAdminCreate struct {
+	FirstName   string
+	LastName    string
+	SecondName  string
+	Email       string
+	Role        string
+	Status      string
+	PhoneNumber *string
+	Department  *string
+	Position    *string
+	Supervisor  *string
+	Address     *string
+	InviteToken string
+	Image       *string
+}
+
+type StaffAdminUpdate struct {
+	FirstName   *string
+	LastName    *string
+	SecondName  *string
+	Email       *string
+	Role        *string
+	Status      *string
+	PhoneNumber *string
+	Department  *string
+	Position    *string
+	Supervisor  *string
+	Address     *string
+	Image       *string
 }

--- a/internal/repository/interfaces.go
+++ b/internal/repository/interfaces.go
@@ -18,6 +18,9 @@ type StaffRepository interface {
 	List(ctx context.Context, role, status, search string, limit, offset int) ([]dto.UserListItem, int, error)
 	GetByID(ctx context.Context, id int64) (*dto.UserWithDetails, error)
 	GetDashboard(ctx context.Context, managerId int64) (*dto.DashboardResponse, error)
+	CreateStaffByAdmin(ctx context.Context, req *models.StaffAdminCreate) (*models.UserAPI, error)
+	UpdateStaff(ctx context.Context, id int64, req *models.StaffAdminUpdate) (*models.UserAPI, error)
+	BlockStaff(ctx context.Context, id int64) (*models.UserAPI, error)
 }
 
 type TelegramUserRepository interface {

--- a/internal/repository/postgres/special_project.go
+++ b/internal/repository/postgres/special_project.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jmoiron/sqlx"
+
 	"github.com/yandex-development-1-team/go/internal/models"
 )
 

--- a/internal/repository/postgres/special_project.go
+++ b/internal/repository/postgres/special_project.go
@@ -8,9 +8,6 @@ import (
 
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jmoiron/sqlx"
-	"go.uber.org/zap"
-
-	"github.com/yandex-development-1-team/go/internal/logger"
 	"github.com/yandex-development-1-team/go/internal/models"
 )
 
@@ -20,27 +17,65 @@ type specialProjectRepo struct {
 
 const (
 	createSpecProjectQuery = `
-		INSERT INTO special_projects (title, description, image, status)
-		VALUES (:title, :description, :image, :status)
-		RETURNING id, title, description, image, status, created_at, updated_at
-	`
+    WITH new_image AS (
+    UPDATE files
+    SET is_active = true
+    WHERE url = $3        -- было $4, должно быть $3 (image)
+        AND $3 IS NOT NULL
+        AND $3 != ''
+)
+	INSERT INTO special_projects (title, description, image, status)
+	VALUES ($1, $2, $3, $4::special_project_status)
+	RETURNING id, title, description, image, status, created_at, updated_at`
+
 	updateSpecProjectQuery = `
-		UPDATE special_projects 
-		SET title = $1, description = $2, image = $3, status = $4
-		WHERE id = $5
-		RETURNING title, description, image, status`
+    WITH
+    old_image AS (
+        SELECT image FROM special_projects WHERE id = $5
+    ),
+    deactivate AS (
+        UPDATE files f
+        SET is_active = false
+        FROM old_image o
+        WHERE f.url = o.image
+            AND o.image IS NOT NULL
+            AND o.image != ''
+            AND $3::text IS NOT NULL
+			AND $3::text != ''
+			AND o.image != $3::text
+    ),
+    activate AS (
+        UPDATE files
+        SET is_active = true
+        WHERE url = $3::text
+			AND $3::text IS NOT NULL
+    		AND $3::text != ''
+    )
+    UPDATE special_projects
+    SET
+        title       = COALESCE($1, title),
+        description = COALESCE($2, description),
+        image = COALESCE(NULLIF($3::text, ''), image),
+        status = COALESCE($4, status),
+        updated_at  = NOW()
+    WHERE id = $5
+    RETURNING id, title, description, image, status, created_at, updated_at`
 
 	getSpecProjectByIDQuery = `SELECT * FROM special_projects WHERE id = $1`
 
 	listSpecProjectsBaseQuery      = `SELECT id, title, status FROM special_projects WHERE 1=1`
 	listSpecProjectsCountBaseQuery = `SELECT COUNT(1) FROM special_projects WHERE 1=1`
 
-	deactivateApplicationsQuery = `
-        UPDATE applications 
-		SET status = 'done', updated_at = now()
-		WHERE special_project_id = $1 AND status IN ('queue', 'in_progress')`
-
 	deleteSpecProjectQuery = `
+    WITH deactivate_image AS (
+        UPDATE files f
+        SET is_active = false
+        FROM special_projects sp
+        WHERE sp.id = $1
+            AND f.url = sp.image
+            AND sp.image IS NOT NULL
+            AND sp.image != ''
+    )
     UPDATE special_projects 
     SET deleted_at = now(), updated_at = now(), status = 'inactive'
     WHERE id = $1 AND deleted_at IS NULL`
@@ -51,20 +86,29 @@ func NewSpecialProjectRepository(db *sqlx.DB) *specialProjectRepo {
 }
 
 func (r *specialProjectRepo) Create(ctx context.Context, proj *models.SpecialProjectDB) (*models.SpecialProjectDB, error) {
-	rows, err := r.db.NamedQueryContext(ctx, createSpecProjectQuery, proj)
-	if err == nil {
-		if rows.Next() {
-			err = rows.StructScan(proj)
-		}
-		_ = rows.Close()
-	}
+	var result models.SpecialProjectDB
+
+	err := r.db.QueryRowContext(ctx, createSpecProjectQuery,
+		proj.Title,
+		proj.Description,
+		proj.Image,
+		proj.Status,
+	).Scan(
+		&result.ID,
+		&result.Title,
+		&result.Description,
+		&result.Image,
+		&result.Status,
+		&result.CreatedAt,
+		&result.UpdatedAt,
+	)
 	if err != nil {
 		if pgErr, ok := err.(*pgconn.PgError); ok && pgErr.Code == "23505" {
 			return nil, fmt.Errorf("%w", models.ErrSpecialProjectAlreadyExists)
 		}
 		return nil, fmt.Errorf("repo create: %w", err)
 	}
-	return proj, nil
+	return &result, nil
 }
 
 func (r *specialProjectRepo) GetByID(ctx context.Context, id int64) (*models.SpecialProjectDB, error) {
@@ -148,7 +192,15 @@ func (r *specialProjectRepo) Update(ctx context.Context, id int64, specialProjec
 		specialProject.Image,
 		specialProject.Status,
 		id,
-	).Scan(&updatedSpecialProject.Title, &updatedSpecialProject.Description, &updatedSpecialProject.Image, &updatedSpecialProject.Status)
+	).Scan(
+		&updatedSpecialProject.ID,
+		&updatedSpecialProject.Title,
+		&updatedSpecialProject.Description,
+		&updatedSpecialProject.Image,
+		&updatedSpecialProject.Status,
+		&updatedSpecialProject.CreatedAt,
+		&updatedSpecialProject.UpdatedAt,
+	)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, models.ErrSpecialProjectNotFound
@@ -159,31 +211,13 @@ func (r *specialProjectRepo) Update(ctx context.Context, id int64, specialProjec
 }
 
 func (r specialProjectRepo) Delete(ctx context.Context, id int64) error {
-	tx, err := r.db.BeginTxx(ctx, nil)
-	if err != nil {
-		return fmt.Errorf("failed to begin transaction: %w", err)
-	}
-	defer func() {
-		if rollbackErr := tx.Rollback(); rollbackErr != nil && !errors.Is(rollbackErr, sql.ErrTxDone) {
-			logger.Error("failed to rollback transaction", zap.Error(rollbackErr))
-		}
-	}()
-
-	if _, err = tx.ExecContext(ctx, deactivateApplicationsQuery, id); err != nil {
-		return fmt.Errorf("failed to deactivate special project in applications: %w", err)
-	}
-
-	res, err := tx.ExecContext(ctx, deleteSpecProjectQuery, id)
+	res, err := r.db.ExecContext(ctx, deleteSpecProjectQuery, id)
 	if err != nil {
 		return fmt.Errorf("failed to delete special project: %w", err)
 	}
 
 	if rowsAffected, _ := res.RowsAffected(); rowsAffected == 0 {
 		return models.ErrSpecialProjectNotFound
-	}
-
-	if err = tx.Commit(); err != nil {
-		return fmt.Errorf("failed to commit transaction: %w", err)
 	}
 
 	return nil

--- a/internal/repository/postgres/staff_repo.go
+++ b/internal/repository/postgres/staff_repo.go
@@ -16,17 +16,17 @@ import (
 
 const getUserByEmailQuery = `
     SELECT id, telegram_nick, first_name, last_name, second_name, email,
-		       phone_number, password_hash, role, status, invite_token, department,
-					 position,  created_at, updated_at
+               phone_number, password_hash, role, status, invite_token, department,
+               position, supervisor, address, image, created_at, updated_at
     FROM staff
     WHERE email = $1`
 
 const createUserQuery = `
-	INSERT INTO staff(first_name, last_name, email, invite_token, password_hash)
-	VALUES ($1, $2, $3, $4, $5)
-	RETURNING id, telegram_nick, first_name, email,
-						role, status,
-						created_at, updated_at
+    INSERT INTO staff(first_name, last_name, email, invite_token, password_hash)
+    VALUES ($1, $2, $3, $4, $5)
+    RETURNING id, telegram_nick, first_name, email,
+              role, status,
+              created_at, updated_at
 `
 const getDashboardOverview = `
 	WITH combined AS (
@@ -88,6 +88,43 @@ const listOfShortApplications = `
 	WHERE manager_id = $1 AND status != 'cancelled'
 	ORDER BY created_at DESC;`
 
+const insertStaffAdminQuery = `
+    INSERT INTO staff (
+        first_name, last_name, second_name, email,
+        phone_number, password_hash, role, status,
+        department, position, image, invite_token, supervisor, address)
+    VALUES ($1, $2, $3, $4, $5, '', $6::user_role_type, $7::user_status_type,
+        $8, $9, $10, $11, $12, $13)
+    RETURNING id, telegram_nick, first_name, last_name, second_name, email,
+        phone_number, role, status, invite_token, department, position,
+        supervisor, address, image, created_at, updated_at`
+
+const updateStaffQuery = `
+    UPDATE staff SET
+        first_name   = COALESCE($2, first_name),
+        last_name    = COALESCE($3, last_name),
+        second_name  = COALESCE($4, second_name),
+        email        = COALESCE($5, email),
+        role         = COALESCE($6::user_role_type, role),
+        status       = COALESCE($7::user_status_type, status),
+        phone_number = COALESCE($8, phone_number),
+        department   = COALESCE($9, department),
+        position     = COALESCE($10, position),
+        supervisor   = COALESCE($11, supervisor),
+        address      = COALESCE($12, address),
+        image        = COALESCE($13, image)
+    WHERE id = $1
+    RETURNING id, telegram_nick, first_name, last_name, second_name, email,
+        phone_number, role, status, invite_token, department, position,
+        supervisor, address, image, created_at, updated_at`
+
+const blockStaffQuery = `
+    UPDATE staff SET status = 'blocked'::user_status_type
+    WHERE id = $1
+    RETURNING id, telegram_nick, first_name, last_name, second_name, email,
+        phone_number, role, status, invite_token, department, position,
+        supervisor, address, image, created_at, updated_at`
+
 type StaffRepo struct {
 	db *sqlx.DB
 }
@@ -146,6 +183,9 @@ func toUser(user *dto.UserRow) *models.UserAPI {
 		Status:       user.Status,
 		Department:   derefString(user.Department),
 		Position:     derefString(user.Position),
+		Supervisor:   derefString(user.Supervisor),
+		Address:      derefString(user.Address),
+		Image:        derefString(user.Image),
 		InviteToken:  derefString(user.InviteToken),
 		CreatedAt:    user.CreatedAt,
 		UpdatedAt:    user.UpdatedAt,
@@ -161,7 +201,7 @@ func derefString(s *string) string {
 
 func (u *StaffRepo) List(ctx context.Context, role, status, search string, limit, offset int) ([]dto.UserListItem, int, error) {
 	query := `
-		SELECT id, telegram_nick, first_name, last_name, role, status, created_at
+		SELECT id, telegram_nick, first_name, last_name, role, status, department, supervisor, position, phone_number, email, created_at
 		FROM staff
 		WHERE 1=1`
 	countQuery := `SELECT COUNT(*) FROM staff WHERE 1=1`
@@ -209,6 +249,11 @@ func (u *StaffRepo) List(ctx context.Context, role, status, search string, limit
 		LastName     string       `db:"last_name"`
 		Role         string       `db:"role"`
 		Status       string       `db:"status"`
+		Department   *string      `db:"department"`
+		Supervisor   *string      `db:"supervisor"`
+		Position     *string      `db:"position"`
+		PhoneNumber  *string      `db:"phone_number"`
+		Email        string       `db:"email"`
 		CreatedAt    sql.NullTime `db:"created_at"`
 	}
 
@@ -229,6 +274,11 @@ func (u *StaffRepo) List(ctx context.Context, role, status, search string, limit
 			Name:         name,
 			Role:         row.Role,
 			Status:       row.Status,
+			Department:   derefString(row.Department),
+			Supervisor:   derefString(row.Supervisor),
+			Position:     derefString(row.Position),
+			PhoneNumber:  derefString(row.PhoneNumber),
+			Email:        row.Email,
 			CreatedAt:    row.CreatedAt.Time,
 		})
 	}
@@ -239,7 +289,8 @@ func (u *StaffRepo) List(ctx context.Context, role, status, search string, limit
 func (u *StaffRepo) GetByID(ctx context.Context, id int64) (*dto.UserWithDetails, error) {
 	userQuery := `
 		SELECT id, telegram_nick, first_name, last_name, second_name, email,
-		       phone_number, role, status, department, position, created_at, updated_at
+		       phone_number, role, status, department, position, address,
+           			supervisor, image, created_at, updated_at
 		FROM staff
 		WHERE id = $1`
 
@@ -255,6 +306,9 @@ func (u *StaffRepo) GetByID(ctx context.Context, id int64) (*dto.UserWithDetails
 		Status       string       `db:"status"`
 		Department   *string      `db:"department"`
 		Position     *string      `db:"position"`
+		Supervisor   *string      `db:"supervisor"`
+		Address      *string      `db:"address"`
+		Image        *string      `db:"image"`
 		CreatedAt    sql.NullTime `db:"created_at"`
 		UpdatedAt    sql.NullTime `db:"updated_at"`
 	}
@@ -361,12 +415,82 @@ func (u *StaffRepo) GetByID(ctx context.Context, id int64) (*dto.UserWithDetails
 		Status:        user.Status,
 		Department:    derefString(user.Department),
 		Position:      derefString(user.Position),
+		Supervisor:    derefString(user.Supervisor),
+		Address:       derefString(user.Address),
+		Image:         derefString(user.Image),
 		CreatedAt:     user.CreatedAt.Time,
 		UpdatedAt:     user.UpdatedAt.Time,
 		Bookings:      bookings,
 		VisitHistory:  visitHistory,
 		FavoriteBoxes: favoriteBoxes,
 	}, nil
+}
+
+func (u *StaffRepo) CreateStaffByAdmin(ctx context.Context, req *models.StaffAdminCreate) (*models.UserAPI, error) {
+	var row dto.UserRow
+
+	err := u.db.GetContext(ctx, &row, insertStaffAdminQuery,
+		req.FirstName,
+		req.LastName,
+		req.SecondName,
+		req.Email,
+		req.PhoneNumber,
+		req.Role,
+		req.Status,
+		req.Department,
+		req.Position,
+		req.InviteToken,
+		req.Supervisor,
+		req.Address,
+		req.Image,
+	)
+	if err != nil {
+		var pqErr *pq.Error
+		if errors.As(err, &pqErr) && pqErr.Code == "23505" {
+			return nil, models.ErrEmailAlreadyExist
+		}
+		return nil, err
+	}
+	return toUser(&row), nil
+}
+
+func (u *StaffRepo) UpdateStaff(ctx context.Context, id int64, req *models.StaffAdminUpdate) (*models.UserAPI, error) {
+	var row dto.UserRow
+
+	err := u.db.GetContext(ctx, &row, updateStaffQuery,
+		id,
+		req.FirstName,
+		req.LastName,
+		req.SecondName,
+		req.Email,
+		req.Role,
+		req.Status,
+		req.PhoneNumber,
+		req.Department,
+		req.Position,
+		req.Supervisor,
+		req.Address,
+		req.Image,
+	)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, models.ErrUserNotFound
+	}
+	if err != nil {
+		return nil, err
+	}
+	return toUser(&row), nil
+}
+
+func (u *StaffRepo) BlockStaff(ctx context.Context, id int64) (*models.UserAPI, error) {
+	var row dto.UserRow
+	err := u.db.GetContext(ctx, &row, blockStaffQuery, id)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, models.ErrUserNotFound
+	}
+	if err != nil {
+		return nil, err
+	}
+	return toUser(&row), nil
 }
 
 func (u *StaffRepo) GetDashboard(ctx context.Context, managerId int64) (*dto.DashboardResponse, error) {

--- a/internal/service/api/api_box.go
+++ b/internal/service/api/api_box.go
@@ -2,6 +2,8 @@ package service
 
 import (
 	"context"
+	"fmt"
+	"io"
 	"time"
 
 	"go.uber.org/zap"
@@ -196,4 +198,47 @@ func parseBoxSlots(slots []models.BoxAvailableSlot) (models.BoxNewSlots, error) 
 	}
 
 	return boxNewSlots, nil
+}
+
+func (s *APIBoxService) UploadImage(
+	ctx context.Context,
+	id int64,
+	reader io.Reader,
+	originalName string,
+	contentType string,
+	size int64,
+) (string, error) {
+	if s.fileService == nil {
+		return "", fmt.Errorf("file service is nil")
+	}
+
+	currentBox, err := s.lister.GetServiceByID(ctx, id)
+	if err != nil {
+		return "", err
+	}
+
+	var oldImage string
+	if currentBox != nil && currentBox.Image != nil {
+		oldImage = *currentBox.Image
+	}
+	uploadResp, err := s.fileService.Upload(ctx, reader, originalName, contentType, size)
+	if err != nil {
+		return "", err
+	}
+
+	updateReq := &models.BoxUpdate{
+		Image: &uploadResp.URL,
+	}
+
+	_, err = s.Update(ctx, id, updateReq)
+	if err != nil {
+		return "", err
+	}
+
+	if oldImage != "" && oldImage != uploadResp.URL {
+		if err := s.fileService.DeactivateByURL(ctx, oldImage); err != nil {
+			return "", err
+		}
+	}
+	return uploadResp.URL, nil
 }

--- a/internal/service/api/user.go
+++ b/internal/service/api/user.go
@@ -2,6 +2,8 @@ package service
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 
 	"github.com/yandex-development-1-team/go/internal/dto"
 	"github.com/yandex-development-1-team/go/internal/models"
@@ -33,6 +35,121 @@ func (s *UserService) GetByID(ctx context.Context, id int64) (*dto.UserWithDetai
 	}
 
 	return s.repo.GetByID(ctx, id)
+}
+
+type UsersAdminService struct {
+	staffRepo repository.StaffRepository
+	rtRepo    repository.RefreshTokenRepository
+}
+
+func NewUsersAdminService(staffRepo repository.StaffRepository, rtRepo repository.RefreshTokenRepository) *UsersAdminService {
+	return &UsersAdminService{staffRepo: staffRepo, rtRepo: rtRepo}
+}
+
+func (s *UsersAdminService) Create(ctx context.Context, req dto.UserCreateRequest) (*models.UserAPI, error) {
+	status := req.Status
+	if status == "" {
+		status = "invited"
+	}
+
+	if err := validateStaffEnums(req.Role, status); err != nil {
+		return nil, err
+	}
+	m := &models.StaffAdminCreate{
+		FirstName:   req.FirstName,
+		LastName:    req.LastName,
+		SecondName:  derefOrEmpty(req.SecondName),
+		Email:       req.Email,
+		Role:        req.Role,
+		Status:      status,
+		PhoneNumber: req.PhoneNumber,
+		Department:  req.Department,
+		Position:    req.Position,
+		Image:       req.Image,
+		Supervisor:  req.Supervisor,
+		Address:     req.Address,
+		InviteToken: generateInviteToken(),
+	}
+	return s.staffRepo.CreateStaffByAdmin(ctx, m)
+}
+
+func (s *UsersAdminService) Update(ctx context.Context, id int64, req dto.UserUpdateRequest) (*models.UserAPI, error) {
+	u := &models.StaffAdminUpdate{
+		FirstName:   req.FirstName,
+		LastName:    req.LastName,
+		SecondName:  req.SecondName,
+		Email:       req.Email,
+		Role:        req.Role,
+		Status:      req.Status,
+		PhoneNumber: req.PhoneNumber,
+		Department:  req.Department,
+		Position:    req.Position,
+		Image:       req.Image,
+		Supervisor:  req.Supervisor,
+		Address:     req.Address,
+	}
+	if u.Role != nil {
+		if err := validateRole(*u.Role); err != nil {
+			return nil, err
+		}
+	}
+	if u.Status != nil {
+		if err := validateStatus(*u.Status); err != nil {
+			return nil, err
+		}
+	}
+	return s.staffRepo.UpdateStaff(ctx, id, u)
+}
+
+func (s *UsersAdminService) Block(ctx context.Context, id int64) (*models.UserAPI, error) {
+	user, err := s.staffRepo.BlockStaff(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	if err := s.rtRepo.DeleteByStaffID(ctx, id); err != nil {
+		return nil, err
+	}
+	return user, nil
+}
+
+func validateStaffEnums(role, status string) error {
+	if err := validateRole(role); err != nil {
+		return err
+	}
+	return validateStatus(status)
+}
+
+func validateRole(role string) error {
+	switch role {
+	case "admin", "manager_1", "manager_2", "manager_3", "user":
+		return nil
+	default:
+		return models.ErrInvalidInput
+	}
+}
+
+func validateStatus(status string) error {
+	switch status {
+	case "active", "blocked", "invited":
+		return nil
+	default:
+		return models.ErrInvalidInput
+	}
+}
+
+func generateInviteToken() string {
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		return ""
+	}
+	return hex.EncodeToString(b)
+}
+
+func derefOrEmpty(s *string) string {
+	if s == nil {
+		return ""
+	}
+	return *s
 }
 
 func (s *UserService) Dashboard(ctx context.Context, managerId int64) (*dto.DashboardResponse, error) {

--- a/migrations/20260208082009_create_staff_table.sql
+++ b/migrations/20260208082009_create_staff_table.sql
@@ -29,6 +29,9 @@ CREATE TABLE IF NOT EXISTS staff (
     status user_status_type DEFAULT 'invited',
     department VARCHAR(255),
     position VARCHAR(255),
+    supervisor VARCHAR(255),
+    address VARCHAR(255),
+    image TEXT,
     invite_token TEXT,
     created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()

--- a/migrations/20260305000944_create_special_projects.sql
+++ b/migrations/20260305000944_create_special_projects.sql
@@ -13,11 +13,14 @@ CREATE TABLE IF NOT EXISTS special_projects (
     image TEXT,
     status spec_type,
     created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    deleted_at TIMESTAMPTZ NULL DEFAULT NULL
 );
 
+CREATE INDEX IF NOT EXISTS idx_special_projects_status ON special_projects (status);
 CREATE INDEX IF NOT EXISTS idx_special_projects_updated_at ON special_projects (updated_at DESC);
 CREATE INDEX IF NOT EXISTS idx_special_projects_search ON special_projects USING GIN (to_tsvector('russian', title || ' ' || COALESCE(description, '')));
 
 -- +goose Down
 DROP TABLE IF EXISTS special_projects;
+DROP TYPE IF EXISTS spec_type;


### PR DESCRIPTION
cmd/bot/main.go
Добавлена инициализация usersAdminService  
Добавлено поле UsersAdmin в APIServices  

internal/api/handlers/users.go
Добавлен новый тип UsersHandler с методами Create, Update, Block — для админских операций над сотрудниками.  
Добавлены поля supervisor и address в маппинг UserResponse  

internal/api/server/routes.go
В сигнатуру SetupRoutes добавлен параметр usersHandler *handlers.UsersHandler  
Добавлен вызов setupUsersAdminRoutes внутри protected  
Добавлена функция setupUsersAdminRoutes — роуты POST /admin/users, PUT /admin/users/:id, PUT /admin/users/:id/block под RequireAdmin (доступ ограничен админом)

internal/api/server/server.go
В APIServices добавлено поле UsersAdmin *apiService.UsersAdminService  
В RegisterRoutes добавлена инициализация usersHandler и передача в SetupRoutes  

internal/dto/users.go
Добавлены три новых типа: UserCreateRequest, UserUpdateRequest, BlockResponse  
Добавлены поля supervisor и address в UserResponse и UserRow  

internal/models/models.go
Добавлены два новых типа в конец файла: StaffAdminCreate, StaffAdminUpdate  

internal/repository/interfaces.go
В интерфейс StaffRepository добавлены три метода: CreateStaffByAdmin, UpdateStaff, BlockStaff  

internal/repository/postgres/staff_repo.go
Добавлены SQL-константы insertStaffAdminQuery, updateStaffQuery, blockStaffQuery  
Добавлены методы CreateStaffByAdmin, UpdateStaff, BlockStaff на StaffRepo  

internal/service/api/user.go
Добавлен новый сервис UsersAdminService с методами Create, Update, Block  
Добавлены вспомогательные функции validateRole, validateStatus, generateInviteToken  

migrations/20260420000000_add_supervisor_address_to_staff.sql
Добавлены колонки supervisor и address в таблицу staff  
Добавлен rollback (DROP COLUMN IF EXISTS)

internal/api/handlers/auth.go
Добавлены поля supervisor и address в UserResponse mapping