### PR TITLE
feat/178: refactor user status endpoint and fix user response fields

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1896,9 +1896,9 @@
         }
       }
     },
-    "/api/v1/users/{id}/block": {
+    "/api/v1/users/{id}/status": {
       "put": {
-        "summary": "Заблокировать пользователя",
+        "summary": "Изменить статус пользователя",
         "tags": [
           "users"
         ],
@@ -1907,9 +1907,26 @@
             "$ref": "#/components/parameters/IdPathParam"
           }
         ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "status": {
+                    "type": "string",
+                    "enum": ["active", "blocked"]
+                  }
+                },
+                "required": ["status"]
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
-            "description": "Пользователь заблокирован",
+            "description": "Статус пользователя изменён",
             "content": {
               "application/json": {
                 "schema": {
@@ -3489,7 +3506,7 @@
           "telegram_nick": {
             "type": "string"
           },
-          "name": {
+          "first_name": {
             "type": "string"
           },
           "last_name": {
@@ -3516,6 +3533,16 @@
           "position": {
             "type": "string"
           },
+          "supervisor": {
+            "type": "string"
+          },
+          "address": {
+            "type": "string"
+          },
+          "image": {
+            "type": "string",
+            "format": "uri"
+          },
           "invite_token": {
             "type": "string"
           },
@@ -3539,7 +3566,13 @@
           "telegram_nick": {
             "type": "string"
           },
-          "name": {
+          "first_name": {
+            "type": "string"
+          },
+          "last_name":  {
+            "type": "string"
+          },
+          "second_name":{
             "type": "string"
           },
           "role": {
@@ -3567,13 +3600,17 @@
             "type": "string"
           },
           "email": {
-            "type": "string"
+            "type": "string",
+            "format": "email"
           },
           "role": {
-            "type": "string"
+            "type": "string",
+            "enum": ["admin", "manager_1", "manager_2", "manager_3", "user"]
           },
           "status": {
-            "type": "string"
+            "type": "string",
+            "enum": ["active", "blocked", "invited"],
+            "default": "invited"
           },
           "phone_number": {
             "type": "string"
@@ -3589,6 +3626,10 @@
           },
           "address": {
             "type": "string"
+          },
+          "image": {
+            "type": "string",
+            "format": "uri"
           }
         },
         "required": [
@@ -3646,6 +3687,10 @@
           },
           "address": {
             "type": "string"
+          },
+          "image": {
+            "type": "string",
+            "format": "uri"
           }
         }
       },

--- a/internal/api/handlers/users.go
+++ b/internal/api/handlers/users.go
@@ -54,20 +54,25 @@ func (h *UsersHandler) Update(c *gin.Context) {
 	c.JSON(http.StatusOK, toUserResponse(user))
 }
 
-func (h *UsersHandler) Block(c *gin.Context) {
+func (h *UsersHandler) UpdateStatus(c *gin.Context) {
 	id, err := strconv.ParseInt(c.Param("id"), 10, 64)
 	if err != nil || id <= 0 {
 		apierrors.WriteErrorMessagesGin(c, http.StatusBadRequest, []string{"Некорректный id"})
 		return
 	}
-	user, err := h.svc.Block(c.Request.Context(), id)
+	var req dto.UpdateStatusRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		apierrors.WriteErrorMessagesGin(c, http.StatusBadRequest, []string{"Некорректный статус"})
+		return
+	}
+	user, err := h.svc.UpdateStatus(c.Request.Context(), id, req.Status)
 	if err != nil {
 		apierrors.WriteErrorGin(c, err)
 		return
 	}
-	c.JSON(http.StatusOK, dto.BlockResponse{
+	c.JSON(http.StatusOK, dto.UpdateStatusResponse{
 		ID:        user.ID,
-		Status:    "blocked",
+		Status:    user.Status,
 		UpdatedAt: user.UpdatedAt,
 	})
 }

--- a/internal/api/handlers/users_test.go
+++ b/internal/api/handlers/users_test.go
@@ -88,7 +88,7 @@ func setupUsersAdminServer(t *testing.T) *httptest.Server {
 	{
 		users.POST("", handler.Create)
 		users.PUT("/:id", handler.Update)
-		users.PUT("/:id/block", handler.Block)
+		users.PUT("/:id/block", handler.UpdateStatus)
 	}
 
 	server := httptest.NewServer(router)
@@ -311,7 +311,8 @@ func TestUsersAdmin_Block_Success(t *testing.T) {
 
 	id := seedStaffAdmin(t, "block@example.com")
 
-	resp, err := doRequest(fmt.Sprintf("%s/users/%d/block", server.URL, id), http.MethodPut, nil, authHeader(token))
+	body, _ := json.Marshal(map[string]interface{}{"status": "blocked"})
+	resp, err := doRequest(fmt.Sprintf("%s/users/%d/block", server.URL, id), http.MethodPut, body, authHeader(token))
 	require.NoError(t, err)
 	defer resp.Body.Close()
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
@@ -335,7 +336,8 @@ func TestUsersAdmin_Block_UserCannotLoginAfterBlock(t *testing.T) {
 		RETURNING id`, string(hash)).Scan(&id)
 	require.NoError(t, err)
 
-	resp, err := doRequest(fmt.Sprintf("%s/users/%d/block", server.URL, id), http.MethodPut, nil, authHeader(token))
+	body, _ := json.Marshal(map[string]interface{}{"status": "blocked"})
+	resp, err := doRequest(fmt.Sprintf("%s/users/%d/block", server.URL, id), http.MethodPut, body, authHeader(token))
 	require.NoError(t, err)
 	resp.Body.Close()
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
@@ -363,7 +365,8 @@ func TestUsersAdmin_Block_RefreshTokensRevoked(t *testing.T) {
 	_ = db.QueryRow(`SELECT COUNT(*) FROM refresh_tokens WHERE user_id = $1`, id).Scan(&count)
 	assert.Equal(t, 1, count)
 
-	resp, err := doRequest(fmt.Sprintf("%s/users/%d/block", server.URL, id), http.MethodPut, nil, authHeader(token))
+	blockBody, _ := json.Marshal(map[string]interface{}{"status": "blocked"})
+	resp, err := doRequest(fmt.Sprintf("%s/users/%d/block", server.URL, id), http.MethodPut, blockBody, authHeader(token))
 	require.NoError(t, err)
 	resp.Body.Close()
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
@@ -377,7 +380,8 @@ func TestUsersAdmin_Block_NotFound(t *testing.T) {
 	server := setupUsersAdminServer(t)
 	token := generateAdminToken(t)
 
-	resp, err := doRequest(server.URL+"/users/99999/block", http.MethodPut, nil, authHeader(token))
+	notFoundBody, _ := json.Marshal(map[string]interface{}{"status": "blocked"})
+	resp, err := doRequest(server.URL+"/users/99999/block", http.MethodPut, notFoundBody, authHeader(token))
 	require.NoError(t, err)
 	defer resp.Body.Close()
 	assert.Equal(t, http.StatusNotFound, resp.StatusCode)

--- a/internal/api/server/routes.go
+++ b/internal/api/server/routes.go
@@ -144,7 +144,7 @@ func setupUsersAdminRoutes(rg *gin.RouterGroup, h *handlers.UsersHandler) {
 	{
 		users.POST("", h.Create)
 		users.PUT("/:id", h.Update)
-		users.PUT("/:id/block", h.Block)
+		users.PUT("/:id/status", h.UpdateStatus)
 	}
 }
 

--- a/internal/dto/users.go
+++ b/internal/dto/users.go
@@ -32,16 +32,22 @@ type UserUpdateRequest struct {
 	SecondName  *string `json:"second_name,omitempty" binding:"omitempty,max=255"`
 }
 
-type BlockResponse struct {
+type UpdateStatusResponse struct {
 	ID        int64     `json:"id"`
 	Status    string    `json:"status"`
 	UpdatedAt time.Time `json:"updated_at"`
 }
 
+type UpdateStatusRequest struct {
+	Status string `json:"status" binding:"required,oneof=active blocked"`
+}
+
 type UserListItem struct {
 	ID           int64     `json:"id"`
 	TelegramNick string    `json:"telegram_nick"`
-	Name         string    `json:"name"`
+	FirstName    string    `json:"first_name"`
+	LastName     string    `json:"last_name"`
+	SecondName   string    `json:"second_name"`
 	Role         string    `json:"role"`
 	Status       string    `json:"status"`
 	Department   string    `json:"department"`
@@ -73,7 +79,7 @@ type VisitHistoryItem struct {
 type UserWithDetails struct {
 	ID            int64              `json:"id"`
 	TelegramNick  string             `json:"telegram_nick"`
-	Name          string             `json:"name"`
+	FirstName     string             `json:"first_name"`
 	LastName      string             `json:"last_name"`
 	SecondName    string             `json:"second_name"`
 	Email         string             `json:"email"`

--- a/internal/repository/interfaces.go
+++ b/internal/repository/interfaces.go
@@ -20,7 +20,7 @@ type StaffRepository interface {
 	GetDashboard(ctx context.Context, managerId int64) (*dto.DashboardResponse, error)
 	CreateStaffByAdmin(ctx context.Context, req *models.StaffAdminCreate) (*models.UserAPI, error)
 	UpdateStaff(ctx context.Context, id int64, req *models.StaffAdminUpdate) (*models.UserAPI, error)
-	BlockStaff(ctx context.Context, id int64) (*models.UserAPI, error)
+	UpdateStaffStatus(ctx context.Context, id int64, status string) (*models.UserAPI, error)
 }
 
 type TelegramUserRepository interface {

--- a/internal/repository/postgres/staff_repo.go
+++ b/internal/repository/postgres/staff_repo.go
@@ -118,8 +118,8 @@ const updateStaffQuery = `
         phone_number, role, status, invite_token, department, position,
         supervisor, address, image, created_at, updated_at`
 
-const blockStaffQuery = `
-    UPDATE staff SET status = 'blocked'::user_status_type
+const updateStaffStatusQuery = `
+    UPDATE staff SET status = $2::user_status_type
     WHERE id = $1
     RETURNING id, telegram_nick, first_name, last_name, second_name, email,
         phone_number, role, status, invite_token, department, position,
@@ -201,7 +201,7 @@ func derefString(s *string) string {
 
 func (u *StaffRepo) List(ctx context.Context, role, status, search string, limit, offset int) ([]dto.UserListItem, int, error) {
 	query := `
-		SELECT id, telegram_nick, first_name, last_name, role, status, department, supervisor, position, phone_number, email, created_at
+		SELECT id, telegram_nick, first_name, last_name, second_name, role, status, department, supervisor, position, phone_number, email, created_at
 		FROM staff
 		WHERE 1=1`
 	countQuery := `SELECT COUNT(*) FROM staff WHERE 1=1`
@@ -247,6 +247,7 @@ func (u *StaffRepo) List(ctx context.Context, role, status, search string, limit
 		TelegramNick *string      `db:"telegram_nick"`
 		FirstName    string       `db:"first_name"`
 		LastName     string       `db:"last_name"`
+		SecondName   string       `db:"second_name"`
 		Role         string       `db:"role"`
 		Status       string       `db:"status"`
 		Department   *string      `db:"department"`
@@ -264,14 +265,12 @@ func (u *StaffRepo) List(ctx context.Context, role, status, search string, limit
 
 	items := make([]dto.UserListItem, 0, len(rows))
 	for _, row := range rows {
-		name := row.FirstName
-		if row.LastName != "" {
-			name += " " + row.LastName
-		}
 		items = append(items, dto.UserListItem{
 			ID:           row.ID,
 			TelegramNick: derefString(row.TelegramNick),
-			Name:         name,
+			FirstName:    row.FirstName,
+			LastName:     row.LastName,
+			SecondName:   row.SecondName,
 			Role:         row.Role,
 			Status:       row.Status,
 			Department:   derefString(row.Department),
@@ -398,15 +397,10 @@ func (u *StaffRepo) GetByID(ctx context.Context, id int64) (*dto.UserWithDetails
 		visitHistory = []dto.VisitHistoryItem{}
 	}
 
-	name := user.FirstName
-	if user.LastName != "" {
-		name += " " + user.LastName
-	}
-
 	return &dto.UserWithDetails{
 		ID:            user.ID,
 		TelegramNick:  derefString(user.TelegramNick),
-		Name:          name,
+		FirstName:     user.FirstName,
 		LastName:      user.LastName,
 		SecondName:    user.SecondName,
 		Email:         user.Email,
@@ -481,9 +475,9 @@ func (u *StaffRepo) UpdateStaff(ctx context.Context, id int64, req *models.Staff
 	return toUser(&row), nil
 }
 
-func (u *StaffRepo) BlockStaff(ctx context.Context, id int64) (*models.UserAPI, error) {
+func (u *StaffRepo) UpdateStaffStatus(ctx context.Context, id int64, status string) (*models.UserAPI, error) {
 	var row dto.UserRow
-	err := u.db.GetContext(ctx, &row, blockStaffQuery, id)
+	err := u.db.GetContext(ctx, &row, updateStaffStatusQuery, id, status)
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, models.ErrUserNotFound
 	}

--- a/internal/service/api/user.go
+++ b/internal/service/api/user.go
@@ -101,13 +101,16 @@ func (s *UsersAdminService) Update(ctx context.Context, id int64, req dto.UserUp
 	return s.staffRepo.UpdateStaff(ctx, id, u)
 }
 
-func (s *UsersAdminService) Block(ctx context.Context, id int64) (*models.UserAPI, error) {
-	user, err := s.staffRepo.BlockStaff(ctx, id)
+func (s *UsersAdminService) UpdateStatus(ctx context.Context, id int64, status string) (*models.UserAPI, error) {
+	user, err := s.staffRepo.UpdateStaffStatus(ctx, id, status)
 	if err != nil {
 		return nil, err
 	}
-	if err := s.rtRepo.DeleteByStaffID(ctx, id); err != nil {
-		return nil, err
+	// удаляем refresh tokens только при блокировке
+	if status == "blocked" {
+		if err := s.rtRepo.DeleteByStaffID(ctx, id); err != nil {
+			return nil, err
+		}
 	}
 	return user, nil
 }

--- a/internal/service/api/user.go
+++ b/internal/service/api/user.go
@@ -107,7 +107,7 @@ func (s *UsersAdminService) UpdateStatus(ctx context.Context, id int64, status s
 		return nil, err
 	}
 	// удаляем refresh tokens только при блокировке
-	if status == "blocked" {
+	if user.Status == "blocked" {
 		if err := s.rtRepo.DeleteByStaffID(ctx, id); err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Переименование PUT /{id}/block → PUT /{id}/status — ручка стала универсальной (не только block)

Рефактор хендлера Block → UpdateStatus с приёмом body { status }

Рефактор репо/сервиса — BlockStaff → UpdateStaffStatus(id, status), SQL теперь принимает параметр вместо хардкода 'blocked'

Логика refresh tokens — удаляются только при блокировке, а не при любом изменении статуса

Фикс ФИО — name → отдельные first_name, last_name, second_name в UserListItem и UserWithDetails

Обновление OpenAPI — добавлен image, supervisor, address в схемы, исправлены enums, переименован путь