### PR TITLE
fix/reset-password: fix wrong email error, reset struct, jwt error

### DIFF
--- a/internal/api/handlers/auth.go
+++ b/internal/api/handlers/auth.go
@@ -120,19 +120,13 @@ func (h *AuthHandler) HandleForgotPassword(c *gin.Context) {
 }
 
 func (h *AuthHandler) HandleResetPassword(c *gin.Context) {
-	token := c.Query("token")
-	if token == "" {
-		apierrors.WriteErrorMessagesGin(c, http.StatusBadRequest, []string{"Токен не указан"})
-		return
-	}
-
-	newPassword := c.Query("password")
-	if newPassword == "" || len(newPassword) < 8 {
+	var req dto.ResetPasswordRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
 		apierrors.WriteErrorMessagesGin(c, http.StatusBadRequest, []string{"Пароль должен содержать минимум 8 символов"})
 		return
 	}
 
-	err := h.svc.ResetPassword(c.Request.Context(), token, newPassword)
+	err := h.svc.ResetPassword(c.Request.Context(), req.Token, req.Password)
 	if err != nil {
 		apierrors.WriteErrorGin(c, err)
 		return

--- a/internal/api/server/routes.go
+++ b/internal/api/server/routes.go
@@ -142,7 +142,7 @@ func setupUsersAdminRoutes(rg *gin.RouterGroup, h *handlers.UsersHandler) {
 	users := rg.Group("/users")
 	users.Use(middleware.RequireAdmin())
 	{
-		users.POST("", h.Create)
+		users.POST("/", h.Create)
 		users.PUT("/:id", h.Update)
 		users.PUT("/:id/status", h.UpdateStatus)
 	}

--- a/internal/apierrors/apierrors.go
+++ b/internal/apierrors/apierrors.go
@@ -38,6 +38,7 @@ var errMappings = []errMapping{
 	{models.ErrEmailAlreadyExist, http.StatusConflict, "Указанный почтовый адрес уже занят"},
 	{models.ErrSlotsNotFound, http.StatusBadRequest, "Слоты коробочного решения не найдены"},
 	{models.ErrBoxSolutionNotFound, http.StatusNotFound, "Коробочное решение не найдено"},
+	{models.ErrInvalidEmail, http.StatusBadRequest, "Email адрес недействительный"},
 }
 
 const defaultMessage = "Произошла ошибка. Попробуйте позже."

--- a/internal/dto/auth.go
+++ b/internal/dto/auth.go
@@ -86,6 +86,6 @@ type ForgotPasswordRequest struct {
 }
 
 type ResetPasswordRequest struct {
-	Token    string `json:"token"    binding:"required"`
+	Token    string `json:"token"    binding:"required,min=100,max=512"`
 	Password string `json:"password" binding:"required,min=8,max=72"`
 }

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -68,6 +68,7 @@ var (
 	ErrSlotsNotFound          = errors.New("slots not found")
 	ErrInvalidSlug            = errors.New("wrong slug")
 	ErrInvalidFileType        = errors.New("wrong format file")
+	ErrInvalidEmail           = errors.New("invalid email address")
 )
 
 var AllowedSlugs = map[string]struct{}{

--- a/internal/service/api/auth.go
+++ b/internal/service/api/auth.go
@@ -6,8 +6,12 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"net"
+	"net/textproto"
+	"strings"
 	"time"
 
+	"github.com/go-mail/mail/v2"
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/jmoiron/sqlx"
 	"golang.org/x/crypto/bcrypt"
@@ -86,10 +90,10 @@ func (s *AuthService) Login(ctx context.Context, email, password string) (*model
 		return nil, models.ErrUserBlocked
 	}
 	if err := bcrypt.CompareHashAndPassword([]byte(authInfo.PassHash), []byte(password)); err != nil {
-		if errors.Is(err, bcrypt.ErrMismatchedHashAndPassword) {
+		if errors.Is(err, bcrypt.ErrMismatchedHashAndPassword) || errors.Is(err, bcrypt.ErrHashTooShort) {
 			return nil, models.ErrInvalidCredentials
 		}
-		return nil, fmt.Errorf("check password: %w", err)
+		return nil, fmt.Errorf("compare password hash: %w", err)
 	}
 	token, err := s.generateAccessToken(user.ID, user.Role)
 	if err != nil {
@@ -201,6 +205,11 @@ func (s *AuthService) Logout(ctx context.Context, refreshToken string) error {
 }
 
 func (s *AuthService) ForgotPassword(ctx context.Context, email string) error {
+	parts := strings.Split(email, "@")
+	if len(parts) != 2 || !domainHasMX(parts[1]) {
+		return models.ErrInvalidEmail
+	}
+
 	var signedToken string
 	err := s.txRepo.RunToTx(ctx, func(txCtx context.Context) error {
 		user, err := s.staffRepo.GetUserByEmail(txCtx, email)
@@ -236,9 +245,15 @@ func (s *AuthService) ForgotPassword(ctx context.Context, email string) error {
 	}
 
 	// Send email
-	err = s.emailSvc.SendPasswordResetEmail(ctx, email, signedToken)
-	if err != nil {
-		return err
+	if err = s.emailSvc.SendPasswordResetEmail(ctx, email, signedToken); err != nil {
+		var sendErr *mail.SendError
+		if errors.As(err, &sendErr) {
+			var textErr *textproto.Error
+			if errors.As(sendErr.Cause, &textErr) && textErr.Code >= 550 && textErr.Code <= 553 {
+				return nil
+			}
+		}
+		return fmt.Errorf("send email: %w", err)
 	}
 
 	return nil
@@ -305,4 +320,9 @@ func generateRandomToken() string {
 		return ""
 	}
 	return hex.EncodeToString(b)
+}
+
+func domainHasMX(domain string) bool {
+	records, err := net.LookupMX(domain)
+	return err == nil && len(records) > 0
 }


### PR DESCRIPTION
1. При логине добавлена проверку на ошибку пустого хэша пароля из бд
2. Добавлена и игнорируется ошибка email при отправке письма для восстановления пароля. Ошибки 500-503 игнорируются.
3. Мелкие фиксы по сбросу и восстановлению пароля